### PR TITLE
Allow c-extension to link with system zstd

### DIFF
--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -12,10 +12,9 @@
 
 #define ZSTD_STATIC_LINKING_ONLY
 #define ZDICT_STATIC_LINKING_ONLY
-#include "mem.h"
-#include "zstd.h"
-#include "zdict.h"
-#include "zstdmt_compress.h"
+#include <zstd.h>
+#include <zdict.h>
+#include <zstdmt_compress.h>
 
 #define PYTHON_ZSTANDARD_VERSION "0.7.0"
 

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,19 @@ except ImportError:
 import setup_zstd
 
 SUPPORT_LEGACY = False
+SYSTEM_ZSTD = False
 
 if "--legacy" in sys.argv:
     SUPPORT_LEGACY = True
     sys.argv.remove("--legacy")
 
+if "--system-zstd" in sys.argv:
+    SYSTEM_ZSTD = True
+    sys.argv.remove("--system-zstd")
+
 # Code for obtaining the Extension instance is in its own module to
 # facilitate reuse in other projects.
-extensions = [setup_zstd.get_c_extension(SUPPORT_LEGACY, 'zstd')]
+extensions = [setup_zstd.get_c_extension(SUPPORT_LEGACY, SYSTEM_ZSTD, 'zstd')]
 
 if cffi:
     import make_cffi

--- a/zstd/zstd.h
+++ b/zstd/zstd.h
@@ -333,7 +333,7 @@ ZSTDLIB_API size_t ZSTD_DStreamOutSize(void);   /*!< recommended size for output
 
 #define ZSTD_WINDOWLOG_MAX_32  25
 #define ZSTD_WINDOWLOG_MAX_64  27
-#define ZSTD_WINDOWLOG_MAX    ((U32)(MEM_32bits() ? ZSTD_WINDOWLOG_MAX_32 : ZSTD_WINDOWLOG_MAX_64))
+#define ZSTD_WINDOWLOG_MAX    ((unsigned)(sizeof(size_t) == 4 ? ZSTD_WINDOWLOG_MAX_32 : ZSTD_WINDOWLOG_MAX_64))
 #define ZSTD_WINDOWLOG_MIN     10
 #define ZSTD_HASHLOG_MAX       ZSTD_WINDOWLOG_MAX
 #define ZSTD_HASHLOG_MIN        6


### PR DESCRIPTION
* Required zstd patch e65aab8e0fa823d91a76490924d1d7a67b485aa2 to avoid
  including "mem.h". This means users won't be able to link with
  unmodified system zstd until the next zstd version is released.
  It also requires that `zstdmt_compress.h` is installed.
* Since the c-extension uses zstd's `pool.h` for threading, its source
  and dependencies are always included.

Tests:
```
# Install zstd-1.1.3 with patch and zstdmt_compress.h
cd ~/zstd
git checkout master
git apply e65aab8e0fa823d91a76490924d1d7a67b485aa2
make install MOREFLAGS=-DZSTD_MULTITHREAD
cp lib/compress/zstdmt_compress.h /usr/local/include
# Test with system and non-system zstd
cd ~/python-zstandard
rm -rf build/
python setup.py test --system-zstd
python3 setup.py test --system-zstd
rm -rf build/
python setup.py test
python3 setup.py test
```