### PR TITLE
Hide all symbols except initialization functions

### DIFF
--- a/setup_zstd.py
+++ b/setup_zstd.py
@@ -106,6 +106,12 @@ def get_c_extension(support_legacy=False, system_zstd=False, name='zstd'):
 
     extra_args = ['-DZSTD_MULTITHREAD']
 
+    if not system_zstd:
+        extra_args.append('-DZSTDLIB_VISIBILITY=')
+        extra_args.append('-DZDICTLIB_VISIBILITY=')
+        extra_args.append('-DZSTDERRORLIB_VISIBILITY=')
+        extra_args.append('-fvisibility=hidden')
+
     if not system_zstd and support_legacy:
         extra_args.append('-DZSTD_LEGACY_SUPPORT=1')
 

--- a/zstd.c
+++ b/zstd.c
@@ -142,6 +142,12 @@ void zstd_module_init(PyObject* m) {
 	frameparams_module_init(m);
 }
 
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#  define PYTHON_ZSTD_VISIBILITY __attribute__ ((visibility ("default")))
+#else
+#  define PYTHON_ZSTD_VISIBILITY
+#endif
+
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef zstd_module = {
 	PyModuleDef_HEAD_INIT,
@@ -151,7 +157,7 @@ static struct PyModuleDef zstd_module = {
 	zstd_methods
 };
 
-PyMODINIT_FUNC PyInit_zstd(void) {
+PYTHON_ZSTD_VISIBILITY PyMODINIT_FUNC PyInit_zstd(void) {
 	PyObject *m = PyModule_Create(&zstd_module);
 	if (m) {
 		zstd_module_init(m);
@@ -163,7 +169,7 @@ PyMODINIT_FUNC PyInit_zstd(void) {
 	return m;
 }
 #else
-PyMODINIT_FUNC initzstd(void) {
+PYTHON_ZSTD_VISIBILITY PyMODINIT_FUNC initzstd(void) {
 	PyObject *m = Py_InitModule3("zstd", zstd_methods, zstd_doc);
 	if (m) {
 		zstd_module_init(m);

--- a/zstd/common/zstd_errors.h
+++ b/zstd/common/zstd_errors.h
@@ -19,10 +19,12 @@ extern "C" {
 
 
 /* =====   ZSTDERRORLIB_API : control library symbols visibility   ===== */
-#if defined(__GNUC__) && (__GNUC__ >= 4)
-#  define ZSTDERRORLIB_VISIBILITY __attribute__ ((visibility ("default")))
-#else
-#  define ZSTDERRORLIB_VISIBILITY
+#ifndef ZSTDERRORLIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define ZSTDERRORLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define ZSTDERRORLIB_VISIBILITY
+#  endif
 #endif
 #if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
 #  define ZSTDERRORLIB_API __declspec(dllexport) ZSTDERRORLIB_VISIBILITY

--- a/zstd/dictBuilder/zdict.h
+++ b/zstd/dictBuilder/zdict.h
@@ -20,10 +20,12 @@ extern "C" {
 
 
 /* =====   ZDICTLIB_API : control library symbols visibility   ===== */
-#if defined(__GNUC__) && (__GNUC__ >= 4)
-#  define ZDICTLIB_VISIBILITY __attribute__ ((visibility ("default")))
-#else
-#  define ZDICTLIB_VISIBILITY
+#ifndef ZDICTLIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define ZDICTLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define ZDICTLIB_VISIBILITY
+#  endif
 #endif
 #if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
 #  define ZDICTLIB_API __declspec(dllexport) ZDICTLIB_VISIBILITY

--- a/zstd/zstd.h
+++ b/zstd/zstd.h
@@ -19,10 +19,12 @@ extern "C" {
 
 
 /* =====   ZSTDLIB_API : control library symbols visibility   ===== */
-#if defined(__GNUC__) && (__GNUC__ >= 4)
-#  define ZSTDLIB_VISIBILITY __attribute__ ((visibility ("default")))
-#else
-#  define ZSTDLIB_VISIBILITY
+#ifndef ZSTDLIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define ZSTDLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define ZSTDLIB_VISIBILITY
+#  endif
 #endif
 #if defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
 #  define ZSTDLIB_API __declspec(dllexport) ZSTDLIB_VISIBILITY


### PR DESCRIPTION
* zstd: Backport [a1280406b012a7a5e4f145e9b39bc96efc7cebd6](https://github.com/facebook/zstd/commit/a1280406b012a7a5e4f145e9b39bc96efc7cebd6) to enable hiding all of zstd's symbols.
* c-ext: Hide all symbols except init functions

Summary:
Only the initialization functions need to be exported.
Hiding all other symbols, especially `zstd` symbols, guarantees that there are no collisions.

Test Plan:
Continuous build.
Manually sanity check and look at exported symbols.
```
> python setup.py build
> python setup.py test
> nm --extern-only --defined-only build/lib.macosx-10.11-x86_64-2.7/zstd.so
000000000003f970 T _initzstd
> python3 setup.py build
> python3 setup.py test
> nm --extern-only --defined-only build/lib.macosx-10.11-x86_64-3.5/zstd.cpython-35m-darwin.so
0000000000054030 T _PyInit_zstd
```