### PR TITLE
Fix typo in readme code example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -624,7 +624,7 @@ Stream Reader API
 ``io.RawIOBase`` interface for reading decompressed output as a stream::
 
    with open(path, 'rb') as fh:
-       dctx = zstd.ZstdDecpmpressor()
+       dctx = zstd.ZstdDecompressor()
        with dctx.stream_reader(fh) as reader:
            while True:
                chunk = reader.read(16384)


### PR DESCRIPTION
I just spent 20 minutes trying to debug this `AttributeError`. Hopefully I'm the only one who will ever need to do that :D