### PR TITLE
Fixed minor typos in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -765,8 +765,8 @@ can no longer be called.
 
 Here is how this API should be used::
 
-   dctx = zstd.ZstdDeompressor()
-   dobj = cctx.decompressobj()
+   dctx = zstd.ZstdDecompressor()
+   dobj = dctx.decompressobj()
    data = dobj.decompress(compressed_chunk_0)
    data = dobj.decompress(compressed_chunk_1)
 


### PR DESCRIPTION
While going through the documentation, I found some misspelled names. Went ahead and corrected them :)