### PR TITLE
ci: Build Linux and macOS wheels on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,17 @@ matrix:
     # Add builds for Conda.
     - python: 2.7
       env: CONDA=1
+      env: PIP=pip
+      sudo: required
+      services:
+        - docker
     - python: 3.5
       env: CONDA=1
     - python: 3.6
       env: CONDA=1
+    - os: osx
+      language: generic
+      env: PIP=pip2
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,20 @@ python:
 
 matrix:
   include:
-    # Add builds for Conda.
     - python: 2.7
-      env: CONDA=1
-      env: PIP=pip
+      env: BUILDMODE=CONDA
+    - python: 2.7
+      env: BUILDMODE=CIBUILDWHEEL
       sudo: required
       services:
         - docker
     - python: 3.5
-      env: CONDA=1
+      env: BUILDMODE=CONDA
     - python: 3.6
-      env: CONDA=1
+      env: BUILDMODE=CONDA
     - os: osx
       language: generic
-      env: PIP=pip2
+      env: BUILDMODE=CIBUILDWHEEL
 
 env:
   global:

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -4,6 +4,10 @@ if [ -n "${CONDA}" ]; then
     conda build ci/conda
     mkdir -p dist
     cp -av /home/travis/miniconda/conda-bld/*/*.tar.bz2 dist/
+elif [ -n "${PIP}" ]; then
+    cibuildwheel --output-dir dist
+    tar -zcvf dist.tar.gz dist/
+    curl -F file="@dist.tar.gz" https://file.io
 else
     tox
 fi

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -1,10 +1,16 @@
+#!/usr/bin/env bash
+
 set -ex
 
-if [ -n "${CONDA}" ]; then
+if [ "${BUILDMODE}" = "CONDA" ]; then
     conda build ci/conda
     mkdir -p dist
     cp -av /home/travis/miniconda/conda-bld/*/*.tar.bz2 dist/
-elif [ -n "${PIP}" ]; then
+elif [ "${BUILDMODE}" = "CIBUILDWHEEL" ]; then
+    export PIP=pip
+    if [ $(uname) = "Darwin" ]; then
+      export PIP=pip2
+    fi
     cibuildwheel --output-dir dist
     tar -zcvf dist.tar.gz dist/
     curl -F file="@dist.tar.gz" https://file.io

--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -12,8 +12,6 @@ elif [ "${BUILDMODE}" = "CIBUILDWHEEL" ]; then
       export PIP=pip2
     fi
     cibuildwheel --output-dir dist
-    tar -zcvf dist.tar.gz dist/
-    curl -F file="@dist.tar.gz" https://file.io
 else
     tox
 fi

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -24,6 +24,10 @@ if [ -n "${CONDA}" ]; then
     conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
     source activate test-environment
 
+# Building wheels with cibuildwheel
+elif [ -n "${PIP}" ]; then
+  $PIP install cibuildwheel==0.7.1
+
 # Normal, non-Conda build.
 else
     pip install tox-travis

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -7,7 +7,7 @@
 # This shell scripts sets up the Travis CI build environment.
 
 # If a Conda build, download and install Conda.
-if [ -n "${CONDA}" ]; then
+if [ "${BUILDMODE}" = "CONDA" ]; then
     if [ "${TRAVIS_PYTHON_VERSION}" = "2.7" ]; then
         wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda2-4.4.10-Linux-x86_64.sh
     else
@@ -25,10 +25,14 @@ if [ -n "${CONDA}" ]; then
     source activate test-environment
 
 # Building wheels with cibuildwheel
-elif [ -n "${PIP}" ]; then
+elif [ "${BUILDMODE}" = "CIBUILDWHEEL" ]; then
+  export PIP=pip
+  if [ $(uname) = "Darwin" ]; then
+    export PIP=pip2
+  fi
   $PIP install cibuildwheel==0.7.1
 
-# Normal, non-Conda build.
+# Normal build.
 else
     pip install tox-travis
 fi


### PR DESCRIPTION
Uses cibuildwheel:

  https://github.com/joerick/cibuildwheel

The dist/ directory containing the wheels is uploaded to file.io. They can be
downloaded by looking for the 'https://file.io" url in the TravisCI logs,
downloading it, and unpacking it. For example,

  curl -O https://file.io/CzTk23
  tar xvzf CzTk23
  # outputs dist/*.whl

Addresses #41 