### PR TITLE
Add test dependency on setup.py

### DIFF
--- a/ci/travis-build.sh
+++ b/ci/travis-build.sh
@@ -70,7 +70,7 @@ elif [ "${BUILDMODE}" = "manylinuxtest" ]; then
     mkdir /tmp/wheels
 
     wheel=$(resolve_wheel)
-    curl ${MANYLINUX_URL}/${wheel} > /tmp/wheels/${wheel}
+    curl --fail -sSL ${MANYLINUX_URL}/${wheel} > /tmp/wheels/${wheel}
 
     pip install /tmp/wheels/${wheel}
 

--- a/setup.py
+++ b/setup.py
@@ -110,4 +110,5 @@ setup(
     ext_modules=extensions,
     test_suite='tests',
     install_requires=install_requires,
+    tests_require=['hypothesis'],
 )


### PR DESCRIPTION
This makes `python setup.py test` work without having hypothesis installed.