### PR TITLE
Refresh debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-zstandard (0.12.0~dev0-1) unstable; urgency=low
+
+  * New version.
+
+ -- Gregory Szorc <gregory.szorc@gmail.com>  Sat, 20 Apr 2019 12:50:58 -0700
+
 python-zstandard (0.9.1-1) unstable; urgency=low
 
   * Initial Debian packaging definition.


### PR DESCRIPTION
Using 0.12.0~dev0 rather than 0.12.0.dev0 because dpkg/apt consider the former smaller than 0.12.0 but not the latter. Used the date of the version bump commit as timestamp.