### PR TITLE
Fix ZstdDecompressor on 64-bit big-endian

### DIFF
--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -68,13 +68,13 @@ static int Decompressor_init(ZstdDecompressor* self, PyObject* args, PyObject* k
 	};
 
 	ZstdCompressionDict* dict = NULL;
-	size_t maxWindowSize = 0;
+	Py_ssize_t maxWindowSize = 0;
 	ZSTD_format_e format = ZSTD_f_zstd1;
 
 	self->dctx = NULL;
 	self->dict = NULL;
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O!II:ZstdDecompressor", kwlist,
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O!nI:ZstdDecompressor", kwlist,
 		&ZstdCompressionDictType, &dict, &maxWindowSize, &format)) {
 		return -1;
 	}


### PR DESCRIPTION
When parsing the python arguments, using "I" (int) in the format string
but passing a pointer to size_t means that, on big endian, we're only
initializing the high-order bits of the size_t.  Use "n" (Py_ssize_t)
format instead, which should be the right size.