### PR TITLE
setup_zstd: Include more units needed with system library

### DIFF
--- a/setup_zstd.py
+++ b/setup_zstd.py
@@ -73,8 +73,10 @@ ext_includes = [
 ]
 
 ext_sources = [
+    'zstd/common/error_private.c',
     'zstd/common/pool.c',
     'zstd/common/threading.c',
+    'zstd/common/zstd_common.c',
     'zstd.c',
     'c-ext/bufferutil.c',
     'c-ext/compressiondict.c',


### PR DESCRIPTION
Building again --system-zstd requires linking more units from common/,
otherwise the extension fails to load due to undefined symbols
(ZSTD_malloc, then ERR_getErrorString).