### PR TITLE
setup_zstd: sort list of files/dirs

### DIFF
--- a/setup_zstd.py
+++ b/setup_zstd.py
@@ -145,7 +145,7 @@ def get_c_extension(
             sources.update(
                 [os.path.join(actual_root, p) for p in zstd_sources_legacy]
             )
-    sources = list(sources)
+    sources = sorted(sources)
 
     include_dirs = set([os.path.join(actual_root, d) for d in ext_includes])
     if not system_zstd:
@@ -156,7 +156,7 @@ def get_c_extension(
             include_dirs.update(
                 [os.path.join(actual_root, d) for d in zstd_includes_legacy]
             )
-    include_dirs = list(include_dirs)
+    include_dirs = sorted(include_dirs)
 
     depends = [os.path.join(actual_root, p) for p in zstd_depends]
 


### PR DESCRIPTION
This is to make the linker produce reproducible .so files; otherwise the
order used when passing to the linker causes differences such as
ordering in the file and even file size.

Tested:
- Built once without this change, twice with this change, compared the
  md5sums of build/*/zstd.*.so for all three. "Without this change" was
  different from the two (identical) ones with this change applied.