### PR TITLE
Fix memory leak with streaming decompression

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -89,6 +89,8 @@ Backwards Compatibility Notes
 Changes
 -------
 
+* Fix a memory-leak in stream_reader decompressor when reader is closed before
+  reading everything.
 * CI now properly uses the ``cffi`` backend when running all tests.
 * ``train_dictionary()`` has been rewritten to use the ``fastcover`` APIs
   and to consistently call ``ZDICT_optimizeTrainFromBuffer_fastCover()``

--- a/c-ext/decompressionreader.c
+++ b/c-ext/decompressionreader.c
@@ -38,6 +38,8 @@ static void decompressionreader_dealloc(ZstdDecompressionReader* self) {
 		PyBuffer_Release(&self->buffer);
 	}
 
+	Py_CLEAR(self->readResult);
+
 	PyObject_Del(self);
 }
 


### PR DESCRIPTION
I've found a memory leak: self->readResult is only freed if we reach the end of input reader. Which means that we leak this buffer if:
* an error occur (e.g. the input isn't zstandard compressed data)
* OR if we don't read the full uncompressed data

The following script reproduce the issue:
```Python
import random
import os
import zstandard


def show_rss():
    os.system("ps wup %d" % os.getpid())


def write_data():
    compressor = zstandard.ZstdCompressor()
    with open('data.zstd', 'wb') as fd:
        writer = compressor.stream_writer(fd)
        # This should be such as result file is bigger than self->readSize
        writer.write(b'py' + os.urandom(256*1024))


def read_partial(decompressor):
    with open('data.zstd', 'rb') as fd:
        with decompressor.stream_reader(fd) as reader:
            py = reader.read(2)
            assert py == b'py'
            # If this next line is uncommented, there is no memory leak 
            # reader.read(256*1024)


if __name__ == '__main__':
    write_data()
    decompressor = zstandard.ZstdDecompressor()
    show_rss()
    for i in range(1001):
        read_partial(decompressor)
        if i % 100 == 0:
            show_rss()
```

Without the PR, I end with RSS of ~140 MB. With this PR, the RSS stay at ~10MB.
