### PR TITLE
make_cffi.py: allow users to override compiler with CC= variable

### DIFF
--- a/make_cffi.py
+++ b/make_cffi.py
@@ -84,7 +84,7 @@ distutils.sysconfig.customize_compiler(compiler)
 # Distutils doesn't set compiler.preprocessor, so invoke the preprocessor
 # manually.
 if compiler.compiler_type == "unix":
-    args = list(compiler.executables["compiler"])
+    args = compiler.compiler
     args.extend(
         ["-E", "-DZSTD_STATIC_LINKING_ONLY", "-DZDICT_STATIC_LINKING_ONLY",]
     )


### PR DESCRIPTION
Before the change build system always used 'cc' compiler on linux.

After the change it uses default compiler or if present compiler
from $CC environment varilable.

Bug: https://github.com/indygreg/python-zstandard/issues/103
Bug: https://bugs.gentoo.org/728330
Closes: https://github.com/indygreg/python-zstandard/issues/117