### PR TITLE
A typo and grammar fixes in the error message raised in the case of versions mismatch

### DIFF
--- a/zstd.c
+++ b/zstd.c
@@ -207,7 +207,7 @@ void zstd_module_init(PyObject* m) {
 	unsigned zstd_ver_no = ZSTD_versionNumber();
 	unsigned our_hardcoded_version = 10405;
 	if (ZSTD_VERSION_NUMBER != our_hardcoded_version || zstd_ver_no != our_hardcoded_version) {
-		PyErr_Format(PyExc_ImportError, "zstd C API mismatch; Python bindings not compiled against expected zstd version ( %u returned by lib, %u hardcoed in headers, %u hardcoded in the cext)", zstd_ver_no, ZSTD_VERSION_NUMBER, our_hardcoded_version);
+		PyErr_Format(PyExc_ImportError, "zstd C API versions mismatch; Python bindings were not compiled/linked against expected zstd version (%u returned by the lib, %u hardcoded in zstd headers, %u hardcoded in the cext)", zstd_ver_no, ZSTD_VERSION_NUMBER, our_hardcoded_version);
 		return;
 	}
 


### PR DESCRIPTION
Your first impression was correct, that PR was not perfect.