### PR TITLE
train_dictionary doc: Fix reST syntax

### DIFF
--- a/zstandard/backend_cffi.py
+++ b/zstandard/backend_cffi.py
@@ -2769,7 +2769,7 @@ def train_dictionary(
     are available in the paper *Effective Construction of Relative Lempel-Ziv
     Dictionaries* (authors: Liao, Petri, Moffat, Wirth).
 
-    The cover algorithm takes parameters ``k` and ``d``. These are the
+    The cover algorithm takes parameters ``k`` and ``d``. These are the
     *segment size* and *dmer size*, respectively. The returned dictionary
     instance created by this function has ``k`` and ``d`` attributes
     containing the values for these parameters. If a ``ZstdCompressionDict``


### PR DESCRIPTION
Hello!
While reading the docs I noticed a formatting typo at: https://python-zstandard.readthedocs.io/en/latest/dictionaries.html#training-dictionaries
Here is a fix.
