### PR TITLE
Fixed `__init__.py` imported modulas gets imported with `zstd` when calling `import zstandard`

### DIFF
--- a/zstandard/__init__.py
+++ b/zstandard/__init__.py
@@ -6,19 +6,20 @@
 
 """Python interface to the Zstandard (zstd) compression library."""
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import as _absolute_import
+from __future__ import unicode_literals as _unicode_literals
 
 # This module serves 2 roles:
 #
 # 1) Export the C or CFFI "backend" through a central module.
 # 2) Implement additional functionality built on top of C or CFFI backend.
 
-import builtins
-import io
-import os
-import platform
+import builtins as _builtins
+import io as _io
+import os as _os
+import platform as _platform
 
-from typing import ByteString
+from typing import ByteString as _ByteString
 
 # Some Python implementations don't support C extensions. That's why we have
 # a CFFI implementation in the first place. The code here import one of our
@@ -32,14 +33,14 @@ from typing import ByteString
 # defining a variable and `setup.py` could write the file with whatever
 # policy was specified at build time. Until someone needs it, we go with
 # the hacky but simple environment variable approach.
-_module_policy = os.environ.get("PYTHON_ZSTANDARD_IMPORT_POLICY", "default")
+_module_policy = _os.environ.get("PYTHON_ZSTANDARD_IMPORT_POLICY", "default")
 
 if _module_policy == "default":
-    if platform.python_implementation() in ("CPython",):
+    if _platform.python_implementation() in ("CPython",):
         from .backend_c import *  # type: ignore
 
         backend = "cext"
-    elif platform.python_implementation() in ("PyPy",):
+    elif _platform.python_implementation() in ("PyPy",):
         from .backend_cffi import *  # type: ignore
 
         backend = "cffi"
@@ -143,13 +144,13 @@ def open(
     else:
         raise ValueError("Invalid mode: {!r}".format(mode))
 
-    if hasattr(os, "PathLike"):
-        types = (str, bytes, os.PathLike)
+    if hasattr(_os, "PathLike"):
+        types = (str, bytes, _os.PathLike)
     else:
         types = (str, bytes)
 
     if isinstance(filename, types):  # type: ignore
-        inner_fh = builtins.open(filename, raw_open_mode)
+        inner_fh = _builtins.open(filename, raw_open_mode)
         closefd = True
     elif hasattr(filename, "read") or hasattr(filename, "write"):
         inner_fh = filename
@@ -167,14 +168,14 @@ def open(
         raise RuntimeError("logic error in zstandard.open() handling open mode")
 
     if "b" not in normalized_mode:
-        return io.TextIOWrapper(
+        return _io.TextIOWrapper(
             fh, encoding=encoding, errors=errors, newline=newline
         )
     else:
         return fh
 
 
-def compress(data: ByteString, level: int = 3) -> bytes:
+def compress(data: _ByteString, level: int = 3) -> bytes:
     """Compress source data using the zstd compression format.
 
     This performs one-shot compression using basic/default compression
@@ -192,7 +193,7 @@ def compress(data: ByteString, level: int = 3) -> bytes:
     return cctx.compress(data)
 
 
-def decompress(data: ByteString, max_output_size: int = 0) -> bytes:
+def decompress(data: _ByteString, max_output_size: int = 0) -> bytes:
     """Decompress a zstd frame into its original data.
 
     This performs one-shot decompression using basic/default compression

--- a/zstandard/backend_cffi.py
+++ b/zstandard/backend_cffi.py
@@ -6,7 +6,8 @@
 
 """Python interface to the Zstandard (zstd) compression library."""
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import as _absolute_import
+from __future__ import unicode_literals as _unicode_literals
 
 # This should match what the C extension exports.
 __all__ = [
@@ -84,8 +85,8 @@ __all__ = [
     "FORMAT_ZSTD1_MAGICLESS",
 ]
 
-import io
-import os
+import io as _io
+import os as _os
 
 from ._cffi import (  # type: ignore
     ffi,
@@ -162,13 +163,13 @@ COMPRESSOBJ_FLUSH_BLOCK = 1
 def _cpu_count():
     # os.cpu_count() was introducd in Python 3.4.
     try:
-        return os.cpu_count() or 0
+        return _os.cpu_count() or 0
     except AttributeError:
         pass
 
     # Linux.
     try:
-        return os.sysconf("SC_NPROCESSORS_ONLN")
+        return _os.sysconf("SC_NPROCESSORS_ONLN")
     except (AttributeError, ValueError):
         pass
 
@@ -815,19 +816,19 @@ class ZstdCompressionWriter(object):
         return False
 
     def readline(self, size=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readlines(self, hint=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def seek(self, offset, whence=None):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def seekable(self):
         return False
 
     def truncate(self, size=None):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def writable(self):
         return True
@@ -836,13 +837,13 @@ class ZstdCompressionWriter(object):
         raise NotImplementedError("writelines() is not yet implemented")
 
     def read(self, size=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readall(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readinto(self, b):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def write(self, data):
         """Send data to the compressor and possibly to the inner stream."""
@@ -1416,10 +1417,10 @@ class ZstdCompressionReader(object):
         return False
 
     def readline(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readlines(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def write(self, data):
         raise OSError("stream is not writable")
@@ -1463,10 +1464,10 @@ class ZstdCompressionReader(object):
         return b"".join(chunks)
 
     def __iter__(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def __next__(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     next = __next__
 
@@ -3106,16 +3107,16 @@ class ZstdDecompressionReader(object):
         return False
 
     def readline(self, size=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readlines(self, hint=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def write(self, data):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def writelines(self, lines):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def isatty(self):
         return False
@@ -3153,10 +3154,10 @@ class ZstdDecompressionReader(object):
         return b"".join(chunks)
 
     def __iter__(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def __next__(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     next = __next__
 
@@ -3342,13 +3343,13 @@ class ZstdDecompressionReader(object):
         self._bytes_decompressed += out_buffer.pos
         return out_buffer.pos
 
-    def seek(self, pos, whence=os.SEEK_SET):
+    def seek(self, pos, whence=_os.SEEK_SET):
         if self._closed:
             raise ValueError("stream is closed")
 
         read_amount = 0
 
-        if whence == os.SEEK_SET:
+        if whence == _os.SEEK_SET:
             if pos < 0:
                 raise OSError("cannot seek to negative position with SEEK_SET")
 
@@ -3359,14 +3360,14 @@ class ZstdDecompressionReader(object):
 
             read_amount = pos - self._bytes_decompressed
 
-        elif whence == os.SEEK_CUR:
+        elif whence == _os.SEEK_CUR:
             if pos < 0:
                 raise OSError(
                     "cannot seek zstd decompression stream " "backwards"
                 )
 
             read_amount = pos
-        elif whence == os.SEEK_END:
+        elif whence == _os.SEEK_END:
             raise OSError(
                 "zstd decompression streams cannot be seeked " "with SEEK_END"
             )
@@ -3508,37 +3509,37 @@ class ZstdDecompressionWriter(object):
         return False
 
     def readline(self, size=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readlines(self, hint=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def seek(self, offset, whence=None):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def seekable(self):
         return False
 
     def tell(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def truncate(self, size=None):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def writable(self):
         return True
 
     def writelines(self, lines):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def read(self, size=-1):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readall(self):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def readinto(self, b):
-        raise io.UnsupportedOperation()
+        raise _io.UnsupportedOperation()
 
     def write(self, data):
         if self._closed:


### PR DESCRIPTION
### **The issue:**
The imported modules in `__init__.py` file (eg. `os`, `platform`) are visible
when using `import zstandard`, which means that the `zstandard`'s
visible attributes and methods includes the following imported modules:
`absolute_import`, `unicode_literals`, `builtins`, `io`, `os`, `platform`, `ByteString`
which can be confusing for the library user when using the `dir()` function

### **The fix:**
Importing modules such as `os` like this so it doesn't get imported with `zstd`:
`>>> import os as _os`
More in PEP8: https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles

**Before:**
```python3
>>> import zstandard
>>> dir(zstandard)
['BLOCKSIZELOG_MAX', 'BLOCKSIZE_MAX', 'BufferSegment', 'BufferSegments', 'BufferWithSegments', 'BufferWithSegmentsCollection', 'ByteString', 'CHAINLOG_MAX', 'CHAINLOG_MIN', 'COMPRESSION_RECOMMENDED_INPUT_SIZE', 'COMPRESSION_RECOMMENDED_OUTPUT_SIZE', 'COMPRESSOBJ_FLUSH_BLOCK', 'COMPRESSOBJ_FLUSH_FINISH', 'CONTENTSIZE_ERROR', 'CONTENTSIZE_UNKNOWN', 'DECOMPRESSION_RECOMMENDED_INPUT_SIZE', 'DECOMPRESSION_RECOMMENDED_OUTPUT_SIZE', 'DICT_TYPE_AUTO', 'DICT_TYPE_FULLDICT', 'DICT_TYPE_RAWCONTENT', 'FLUSH_BLOCK', 'FLUSH_FRAME', 'FORMAT_ZSTD1', 'FORMAT_ZSTD1_MAGICLESS', 'FRAME_HEADER', 'FrameParameters', 'HASHLOG3_MAX', 'HASHLOG_MAX', 'HASHLOG_MIN', 'LDM_BUCKETSIZELOG_MAX', 'LDM_MINMATCH_MAX', 'LDM_MINMATCH_MIN', 'MAGIC_NUMBER', 'MAX_COMPRESSION_LEVEL', 'MINMATCH_MAX', 'MINMATCH_MIN', 'SEARCHLENGTH_MAX', 'SEARCHLENGTH_MIN', 'SEARCHLOG_MAX', 'SEARCHLOG_MIN', 'STRATEGY_BTLAZY2', 'STRATEGY_BTOPT', 'STRATEGY_BTULTRA', 'STRATEGY_BTULTRA2', 'STRATEGY_DFAST', 'STRATEGY_FAST', 'STRATEGY_GREEDY', 'STRATEGY_LAZY', 'STRATEGY_LAZY2', 'TARGETLENGTH_MAX', 'TARGETLENGTH_MIN', 'WINDOWLOG_MAX', 'WINDOWLOG_MIN', 'ZSTD_VERSION', 'ZstdCompressionDict', 'ZstdCompressionParameters', 'ZstdCompressor', 'ZstdDecompressor', 'ZstdError', '_MODE_CLOSED', '_MODE_READ', '_MODE_WRITE', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_module_policy', 'absolute_import', 'backend', 'backend_c', 'backend_features', 'builtins', 'compress', 'decompress', 'estimate_decompression_context_size', 'frame_content_size', 'frame_header_size', 'get_frame_parameters', 'io', 'open', 'os', 'platform', 'train_dictionary', 'unicode_literals']
```

**After:**
```python3
>>> import zstandard
>>> dir(zstandard)
['BLOCKSIZELOG_MAX', 'BLOCKSIZE_MAX', 'BufferSegment', 'BufferSegments', 'BufferWithSegments', 'BufferWithSegmentsCollection', 'CHAINLOG_MAX', 'CHAINLOG_MIN', 'COMPRESSION_RECOMMENDED_INPUT_SIZE', 'COMPRESSION_RECOMMENDED_OUTPUT_SIZE', 'COMPRESSOBJ_FLUSH_BLOCK', 'COMPRESSOBJ_FLUSH_FINISH', 'CONTENTSIZE_ERROR', 'CONTENTSIZE_UNKNOWN', 'DECOMPRESSION_RECOMMENDED_INPUT_SIZE', 'DECOMPRESSION_RECOMMENDED_OUTPUT_SIZE', 'DICT_TYPE_AUTO', 'DICT_TYPE_FULLDICT', 'DICT_TYPE_RAWCONTENT', 'FLUSH_BLOCK', 'FLUSH_FRAME', 'FORMAT_ZSTD1', 'FORMAT_ZSTD1_MAGICLESS', 'FRAME_HEADER', 'FrameParameters', 'HASHLOG3_MAX', 'HASHLOG_MAX', 'HASHLOG_MIN', 'LDM_BUCKETSIZELOG_MAX', 'LDM_MINMATCH_MAX', 'LDM_MINMATCH_MIN', 'MAGIC_NUMBER', 'MAX_COMPRESSION_LEVEL', 'MINMATCH_MAX', 'MINMATCH_MIN', 'SEARCHLENGTH_MAX', 'SEARCHLENGTH_MIN', 'SEARCHLOG_MAX', 'SEARCHLOG_MIN', 'STRATEGY_BTLAZY2', 'STRATEGY_BTOPT', 'STRATEGY_BTULTRA', 'STRATEGY_BTULTRA2', 'STRATEGY_DFAST', 'STRATEGY_FAST', 'STRATEGY_GREEDY', 'STRATEGY_LAZY', 'STRATEGY_LAZY2', 'TARGETLENGTH_MAX', 'TARGETLENGTH_MIN', 'WINDOWLOG_MAX', 'WINDOWLOG_MIN', 'ZSTD_VERSION', 'ZstdCompressionDict', 'ZstdCompressionParameters', 'ZstdCompressor', 'ZstdDecompressor', 'ZstdError', '_MODE_CLOSED', '_MODE_READ', '_MODE_WRITE', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', '_module_policy', 'backend', 'backend_c', 'backend_features', 'compress', 'decompress', 'estimate_decompression_context_size', 'frame_content_size', 'frame_header_size', 'get_frame_parameters', 'open', 'train_dictionary']
```