### PR TITLE
Accept None value in ZstdCompressor/ZstdDecompressor constructors parameters

### DIFF
--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -58,17 +58,28 @@ static int Decompressor_init(ZstdDecompressor *self, PyObject *args,
                              PyObject *kwargs) {
     static char *kwlist[] = {"dict_data", "max_window_size", "format", NULL};
 
-    ZstdCompressionDict *dict = NULL;
+    PyObject *dict = NULL;
     Py_ssize_t maxWindowSize = 0;
     ZSTD_format_e format = ZSTD_f_zstd1;
 
     self->dctx = NULL;
     self->dict = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|O!nI:ZstdDecompressor",
-                                     kwlist, &ZstdCompressionDictType, &dict,
-                                     &maxWindowSize, &format)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OnI:ZstdDecompressor",
+                                     kwlist, &dict, &maxWindowSize, &format)) {
         return -1;
+    }
+
+    if (dict) {
+        if (dict == Py_None) {
+            dict = NULL;
+        }
+        else if (!PyObject_IsInstance(dict,
+                                      (PyObject *)&ZstdCompressionDictType)) {
+            PyErr_Format(PyExc_TypeError,
+                         "dict_data must be zstd.ZstdCompressionDict");
+            return -1;
+        }
     }
 
     self->dctx = ZSTD_createDCtx();
@@ -81,7 +92,7 @@ static int Decompressor_init(ZstdDecompressor *self, PyObject *args,
     self->format = format;
 
     if (dict) {
-        self->dict = dict;
+        self->dict = (ZstdCompressionDict *)dict;
         Py_INCREF(dict);
     }
 

--- a/zstandard/__init__.pyi
+++ b/zstandard/__init__.pyi
@@ -265,11 +265,11 @@ class ZstdCompressor(object):
     def __init__(
         self,
         level: int = ...,
-        dict_data: ZstdCompressionDict = ...,
-        compression_params: ZstdCompressionParameters = ...,
-        write_checksum: bool = ...,
-        write_content_size: bool = ...,
-        write_dict_id: bool = ...,
+        dict_data: Optional[ZstdCompressionDict] = ...,
+        compression_params: Optional[ZstdCompressionParameters] = ...,
+        write_checksum: Optional[bool] = ...,
+        write_content_size: Optional[bool] = ...,
+        write_dict_id: Optional[bool] = ...,
         threads: int = ...,
     ): ...
     def memory_size(self) -> int: ...
@@ -376,7 +376,7 @@ class ZstdDecompressionWriter(BinaryIO):
 class ZstdDecompressor(object):
     def __init__(
         self,
-        dict_data: ZstdCompressionDict = ...,
+        dict_data: Optional[ZstdCompressionDict] = ...,
         max_window_size: int = ...,
         format: int = ...,
     ): ...


### PR DESCRIPTION
Change constructors of `ZstdCompressor` and `ZstdDecompressor` to accept explicit `None` value for optional parameters (eg: `dict_data`). Also changing stubs to reflect this.