### PR TITLE
fix inconsistent type for `closed` attribute

### DIFF
--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -127,7 +127,7 @@ typedef struct {
     size_t outSize;
     int entered;
     int closing;
-    int closed;
+    char closed;
     int writeReturnRead;
     int closefd;
     unsigned long long bytesCompressed;
@@ -164,7 +164,7 @@ typedef struct {
     int closefd;
 
     int entered;
-    int closed;
+    char closed;
     unsigned long long bytesCompressed;
 
     ZSTD_inBuffer input;
@@ -244,7 +244,7 @@ typedef struct {
     /* Whether the context manager is active. */
     int entered;
     /* Whether we've closed the stream. */
-    int closed;
+    char closed;
 
     /* Number of bytes decompressed and returned to user. */
     unsigned long long bytesDecompressed;
@@ -271,7 +271,7 @@ typedef struct {
     size_t outSize;
     int entered;
     int closing;
-    int closed;
+    char closed;
     int writeReturnRead;
     int closefd;
 } ZstdDecompressionWriter;


### PR DESCRIPTION
In `Zstd(De)?Compression(Reader|Writer)` structs, `closed` is declared as `int`:
```C
typedef struct {
    PyObject_HEAD
    ...
    int closed;
    ...
} ZstdCompressionWriter;
```
but in [`PyMemberDef`](https://docs.python.org/3/c-api/structures.html#c.PyMemberDef), it's `T_BOOL`:
```C
static PyMemberDef ZstdCompressionWriter_members[] = {
    {"closed", T_BOOL, offsetof(ZstdCompressionWriter, closed), READONLY, NULL},
    {NULL}};
```
which is `char`.

This fixes regression tests on s390x (#105).