### PR TITLE
Expose Zstd{Dec,C}ompression{Read,Writ}er from C extension

### DIFF
--- a/c-ext/compressionreader.c
+++ b/c-ext/compressionreader.c
@@ -844,4 +844,7 @@ void compressionreader_module_init(PyObject *mod) {
     if (PyType_Ready(&ZstdCompressionReaderType) < 0) {
         return;
     }
+
+    Py_INCREF((PyObject *)&ZstdCompressionReaderType);
+    PyModule_AddObject(mod, "ZstdCompressionReader", (PyObject *)&ZstdCompressionReaderType);
 }

--- a/c-ext/compressionwriter.c
+++ b/c-ext/compressionwriter.c
@@ -371,4 +371,7 @@ void compressionwriter_module_init(PyObject *mod) {
     if (PyType_Ready(&ZstdCompressionWriterType) < 0) {
         return;
     }
+    
+    Py_INCREF((PyObject *)&ZstdCompressionWriterType);
+    PyModule_AddObject(mod, "ZstdCompressionWriter", (PyObject *)&ZstdCompressionWriterType);
 }

--- a/c-ext/decompressionreader.c
+++ b/c-ext/decompressionreader.c
@@ -812,4 +812,7 @@ void decompressionreader_module_init(PyObject *mod) {
     if (PyType_Ready(&ZstdDecompressionReaderType) < 0) {
         return;
     }
+
+    Py_INCREF((PyObject *)&ZstdDecompressionReaderType);
+    PyModule_AddObject(mod, "ZstdDecompressionReader", (PyObject *)&ZstdDecompressionReaderType);
 }

--- a/c-ext/decompressionwriter.c
+++ b/c-ext/decompressionwriter.c
@@ -292,4 +292,7 @@ void decompressionwriter_module_init(PyObject *mod) {
     if (PyType_Ready(&ZstdDecompressionWriterType) < 0) {
         return;
     }
+    
+    Py_INCREF((PyObject *)&ZstdDecompressionWriterType);
+    PyModule_AddObject(mod, "ZstdDecompressionWriter", (PyObject *)&ZstdDecompressionWriterType);
 }


### PR DESCRIPTION
This is useful for doing `isinstance` checks on the result of `.open()` calls.