### PR TITLE
Add iterator methods, so the writer looks more file-like

### DIFF
--- a/c-ext/compressionwriter.c
+++ b/c-ext/compressionwriter.c
@@ -290,6 +290,8 @@ static PyMethodDef ZstdCompressionWriter_methods[] = {
      PyDoc_STR("Enter a compression context.")},
     {"__exit__", (PyCFunction)ZstdCompressionWriter_exit, METH_VARARGS,
      PyDoc_STR("Exit a compression context.")},
+    {"__iter__", (PyCFunction)ZstdCompressionWriter_unsupported, METH_NOARGS, NULL},
+    {"__next__", (PyCFunction)ZstdCompressionWriter_unsupported, METH_NOARGS, NULL},
     {"close", (PyCFunction)ZstdCompressionWriter_close, METH_NOARGS, NULL},
     {"fileno", (PyCFunction)ZstdCompressionWriter_fileno, METH_NOARGS, NULL},
     {"isatty", (PyCFunction)ZstdCompressionWriter_false, METH_NOARGS, NULL},

--- a/tests/test_compressor_stream_writer.py
+++ b/tests/test_compressor_stream_writer.py
@@ -21,6 +21,12 @@ class TestCompressor_stream_writer(unittest.TestCase):
 
         self.assertFalse(writer.isatty())
         self.assertFalse(writer.readable())
+        
+        with self.assertRaises(io.UnsupportedOperation):
+            writer.__iter__()
+
+        with self.assertRaises(io.UnsupportedOperation):
+            writer.__next__()
 
         with self.assertRaises(io.UnsupportedOperation):
             writer.readline()

--- a/tests/test_decompressor_stream_writer.py
+++ b/tests/test_decompressor_stream_writer.py
@@ -32,6 +32,12 @@ class TestDecompressor_stream_writer(unittest.TestCase):
         self.assertFalse(writer.readable())
 
         with self.assertRaises(io.UnsupportedOperation):
+            writer.__iter__()
+
+        with self.assertRaises(io.UnsupportedOperation):
+            writer.__next__()
+
+        with self.assertRaises(io.UnsupportedOperation):
             writer.readline()
 
         with self.assertRaises(io.UnsupportedOperation):

--- a/zstandard/backend_cffi.py
+++ b/zstandard/backend_cffi.py
@@ -778,6 +778,12 @@ class ZstdCompressionWriter(object):
 
         return False
 
+    def __iter__(self):
+        raise io.UnsupportedOperation()
+
+    def __next__(self):
+        raise io.UnsupportedOperation()
+
     def memory_size(self):
         return lib.ZSTD_sizeof_CCtx(self._compressor._cctx)
 


### PR DESCRIPTION
Solves https://github.com/indygreg/python-zstandard/issues/167, so pandas can use `stream_writer` to write to compressed streams.