### PR TITLE
Fix assertion failure when calling decompress multiple times

### DIFF
--- a/c-ext/decompressobj.c
+++ b/c-ext/decompressobj.c
@@ -95,7 +95,7 @@ static PyObject *DecompressionObj_decompress(ZstdDecompressionObj *self,
 
         if (zresult == 0 || (input.pos == input.size && output.pos == 0)) {
             /* We should only get here at most once. */
-            assert(!self->unused_data);
+            assert(!self->unused_data || PyBytes_Size(self->unused_data) == 0);
             self->unused_data = PyBytes_FromStringAndSize((char *)(input.src) + input.pos, input.size - input.pos);
 
             break;

--- a/tests/test_decompressor_decompressobj.py
+++ b/tests/test_decompressor_decompressobj.py
@@ -73,6 +73,24 @@ class TestDecompressor_decompressobj(unittest.TestCase):
             dobj.decompress(data)
             self.assertEqual(dobj.flush(), b"")
 
+    def test_multiple_decompress_calls(self):
+        expected = b"foobar"*10
+        data = zstd.ZstdCompressor(level=1).compress(expected)
+
+        N = 3
+        partitioned_data = [data[len(data) * i // N:len(data) * (i + 1) // N] for i in range(N)]
+
+        dctx = zstd.ZstdDecompressor()
+        dobj = dctx.decompressobj()
+
+        for partition in partitioned_data[:-1]:
+          decompressed = dobj.decompress(partition)
+          self.assertEqual(decompressed, b"")
+          self.assertEqual(dobj.unused_data, b"")
+
+        decompressed = dobj.decompress(partitioned_data[-1])
+        self.assertEqual(decompressed, expected)
+
     def test_bad_write_size(self):
         dctx = zstd.ZstdDecompressor()
 


### PR DESCRIPTION
- Add a test that emulates the calling pattern in https://github.com/apache/beam/issues/22939 
- Address the assertion failure by checking size of `unused_data` (please advise if there's a better solution here)