### PR TITLE
Use PyType_Spec to define types instead of PyTypeObject.

### DIFF
--- a/c-ext/bufferutil.c
+++ b/c-ext/bufferutil.c
@@ -502,63 +502,30 @@ BufferWithSegmentsCollection_item(ZstdBufferWithSegmentsCollection *self,
     return NULL;
 }
 
-static PySequenceMethods BufferWithSegmentsCollection_sq = {
-    (lenfunc)BufferWithSegmentsCollection_length,    /* sq_length */
-    0,                                               /* sq_concat */
-    0,                                               /* sq_repeat */
-    (ssizeargfunc)BufferWithSegmentsCollection_item, /* sq_item */
-    0,                                               /* sq_ass_item */
-    0,                                               /* sq_contains */
-    0,                                               /* sq_inplace_concat */
-    0                                                /* sq_inplace_repeat */
-};
-
 static PyMethodDef BufferWithSegmentsCollection_methods[] = {
     {"size", (PyCFunction)BufferWithSegmentsCollection_size, METH_NOARGS,
      PyDoc_STR("total size in bytes of all segments")},
     {NULL, NULL}};
 
-PyTypeObject ZstdBufferWithSegmentsCollectionType = {
-    PyVarObject_HEAD_INIT(NULL,
-                          0) "zstd.BufferWithSegmentsCollection", /* tp_name */
-    sizeof(ZstdBufferWithSegmentsCollection),         /* tp_basicsize */
-    0,                                                /* tp_itemsize */
-    (destructor)BufferWithSegmentsCollection_dealloc, /* tp_dealloc */
-    0,                                                /* tp_print */
-    0,                                                /* tp_getattr */
-    0,                                                /* tp_setattr */
-    0,                                                /* tp_compare */
-    0,                                                /* tp_repr */
-    0,                                                /* tp_as_number */
-    &BufferWithSegmentsCollection_sq,                 /* tp_as_sequence */
-    0,                                                /* tp_as_mapping */
-    0,                                                /* tp_hash  */
-    0,                                                /* tp_call */
-    0,                                                /* tp_str */
-    0,                                                /* tp_getattro */
-    0,                                                /* tp_setattro */
-    0,                                                /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                               /* tp_flags */
-    0,                                                /* tp_doc */
-    0,                                                /* tp_traverse */
-    0,                                                /* tp_clear */
-    0,                                                /* tp_richcompare */
-    0,                                                /* tp_weaklistoffset */
-    /* TODO implement iterator for performance. */
-    0,                                           /* tp_iter */
-    0,                                           /* tp_iternext */
-    BufferWithSegmentsCollection_methods,        /* tp_methods */
-    0,                                           /* tp_members */
-    0,                                           /* tp_getset */
-    0,                                           /* tp_base */
-    0,                                           /* tp_dict */
-    0,                                           /* tp_descr_get */
-    0,                                           /* tp_descr_set */
-    0,                                           /* tp_dictoffset */
-    (initproc)BufferWithSegmentsCollection_init, /* tp_init */
-    0,                                           /* tp_alloc */
-    PyType_GenericNew,                           /* tp_new */
+PyType_Slot ZstdBufferWithSegmentsCollectionSlots[] = {
+    {Py_tp_dealloc, BufferWithSegmentsCollection_dealloc},
+    {Py_sq_length, BufferWithSegmentsCollection_length},
+    {Py_sq_item, BufferWithSegmentsCollection_item},
+    {Py_tp_methods, BufferWithSegmentsCollection_methods},
+    {Py_tp_init, BufferWithSegmentsCollection_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
+
+PyType_Spec ZstdBufferWithSegmentsCollectionSpec = {
+    "zstd.BufferWithSegmentsCollection",
+    sizeof(ZstdBufferWithSegmentsCollection),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    ZstdBufferWithSegmentsCollectionSlots,
+};
+
+PyTypeObject *ZstdBufferWithSegmentsCollectionType;
 
 void bufferutil_module_init(PyObject *mod) {
     ZstdBufferWithSegmentsType =
@@ -599,12 +566,13 @@ void bufferutil_module_init(PyObject *mod) {
     Py_INCREF(ZstdBufferSegmentType);
     PyModule_AddObject(mod, "BufferSegment", (PyObject *)ZstdBufferSegmentType);
 
-    Py_SET_TYPE(&ZstdBufferWithSegmentsCollectionType, &PyType_Type);
-    if (PyType_Ready(&ZstdBufferWithSegmentsCollectionType) < 0) {
+    ZstdBufferWithSegmentsCollectionType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdBufferWithSegmentsCollectionSpec);
+    if (PyType_Ready(ZstdBufferWithSegmentsCollectionType) < 0) {
         return;
     }
 
-    Py_INCREF(&ZstdBufferWithSegmentsCollectionType);
+    Py_INCREF(ZstdBufferWithSegmentsCollectionType);
     PyModule_AddObject(mod, "BufferWithSegmentsCollection",
-                       (PyObject *)&ZstdBufferWithSegmentsCollectionType);
+                       (PyObject *)ZstdBufferWithSegmentsCollectionType);
 }

--- a/c-ext/compressionchunker.c
+++ b/c-ext/compressionchunker.c
@@ -301,46 +301,22 @@ static PyMethodDef ZstdCompressionChunker_methods[] = {
      METH_VARARGS | METH_KEYWORDS, PyDoc_STR("finish compression operation")},
     {NULL, NULL}};
 
-PyTypeObject ZstdCompressionChunkerType = {
-    PyVarObject_HEAD_INIT(NULL,
-                          0) "zstd.ZstdCompressionChunkerType", /* tp_name */
-    sizeof(ZstdCompressionChunker),             /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    (destructor)ZstdCompressionChunker_dealloc, /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_compare */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    0,                                          /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
-    0,                                          /* tp_doc */
-    0,                                          /* tp_traverse */
-    0,                                          /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    ZstdCompressionChunker_methods,             /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    PyType_GenericNew,                          /* tp_new */
+PyType_Slot ZstdCompressionChunkerSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionChunker_dealloc},
+    {Py_tp_methods, ZstdCompressionChunker_methods},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
+
+PyType_Spec ZstdCompressionChunkerSpec = {
+    "zstd.ZstdCompressionChunkerType",
+    sizeof(ZstdCompressionChunker),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionChunkerSlots,
+};
+
+PyTypeObject *ZstdCompressionChunkerType;
 
 void compressionchunker_module_init(PyObject *module) {
     Py_SET_TYPE(&ZstdCompressionChunkerIteratorType, &PyType_Type);
@@ -348,8 +324,9 @@ void compressionchunker_module_init(PyObject *module) {
         return;
     }
 
-    Py_SET_TYPE(&ZstdCompressionChunkerType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionChunkerType) < 0) {
+    ZstdCompressionChunkerType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionChunkerSpec);
+    if (PyType_Ready(ZstdCompressionChunkerType) < 0) {
         return;
     }
 }

--- a/c-ext/compressionchunker.c
+++ b/c-ext/compressionchunker.c
@@ -135,46 +135,23 @@ ZstdCompressionChunkerIterator_iternext(ZstdCompressionChunkerIterator *self) {
     return chunk;
 }
 
-PyTypeObject ZstdCompressionChunkerIteratorType = {
-    PyVarObject_HEAD_INIT(
-        NULL, 0) "zstd.ZstdCompressionChunkerIterator", /* tp_name */
-    sizeof(ZstdCompressionChunkerIterator),             /* tp_basicsize */
-    0,                                                  /* tp_itemsize */
-    (destructor)ZstdCompressionChunkerIterator_dealloc, /* tp_dealloc */
-    0,                                                  /* tp_print */
-    0,                                                  /* tp_getattr */
-    0,                                                  /* tp_setattr */
-    0,                                                  /* tp_compare */
-    0,                                                  /* tp_repr */
-    0,                                                  /* tp_as_number */
-    0,                                                  /* tp_as_sequence */
-    0,                                                  /* tp_as_mapping */
-    0,                                                  /* tp_hash */
-    0,                                                  /* tp_call */
-    0,                                                  /* tp_str */
-    0,                                                  /* tp_getattro */
-    0,                                                  /* tp_setattro */
-    0,                                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,           /* tp_flags */
-    0,                                                  /* tp_doc */
-    0,                                                  /* tp_traverse */
-    0,                                                  /* tp_clear */
-    0,                                                  /* tp_richcompare */
-    0,                                                  /* tp_weaklistoffset */
-    ZstdCompressionChunkerIterator_iter,                /* tp_iter */
-    (iternextfunc)ZstdCompressionChunkerIterator_iternext, /* tp_iternext */
-    0,                                                     /* tp_methods */
-    0,                                                     /* tp_members */
-    0,                                                     /* tp_getset */
-    0,                                                     /* tp_base */
-    0,                                                     /* tp_dict */
-    0,                                                     /* tp_descr_get */
-    0,                                                     /* tp_descr_set */
-    0,                                                     /* tp_dictoffset */
-    0,                                                     /* tp_init */
-    0,                                                     /* tp_alloc */
-    PyType_GenericNew,                                     /* tp_new */
+PyType_Slot ZstdCompressionChunkerIteratorSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionChunkerIterator_dealloc},
+    {Py_tp_iter, ZstdCompressionChunkerIterator_iter},
+    {Py_tp_iternext, ZstdCompressionChunkerIterator_iternext},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
+
+PyType_Spec ZstdCompressionChunkerIteratorSpec = {
+    "zstd.ZstdCompressionChunkerIterator",
+    sizeof(ZstdCompressionChunkerIterator),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionChunkerIteratorSlots,
+};
+
+PyTypeObject *ZstdCompressionChunkerIteratorType;
 
 static void ZstdCompressionChunker_dealloc(ZstdCompressionChunker *self) {
     PyBuffer_Release(&self->inBuffer);
@@ -213,7 +190,7 @@ ZstdCompressionChunker_compress(ZstdCompressionChunker *self, PyObject *args,
     }
 
     result = (ZstdCompressionChunkerIterator *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionChunkerIteratorType, NULL);
+        (PyObject *)ZstdCompressionChunkerIteratorType, NULL);
     if (!result) {
         PyBuffer_Release(&self->inBuffer);
         return NULL;
@@ -248,7 +225,7 @@ ZstdCompressionChunker_finish(ZstdCompressionChunker *self) {
     }
 
     result = (ZstdCompressionChunkerIterator *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionChunkerIteratorType, NULL);
+        (PyObject *)ZstdCompressionChunkerIteratorType, NULL);
     if (!result) {
         return NULL;
     }
@@ -279,7 +256,7 @@ ZstdCompressionChunker_flush(ZstdCompressionChunker *self, PyObject *args,
     }
 
     result = (ZstdCompressionChunkerIterator *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionChunkerIteratorType, NULL);
+        (PyObject *)ZstdCompressionChunkerIteratorType, NULL);
     if (!result) {
         return NULL;
     }
@@ -319,8 +296,9 @@ PyType_Spec ZstdCompressionChunkerSpec = {
 PyTypeObject *ZstdCompressionChunkerType;
 
 void compressionchunker_module_init(PyObject *module) {
-    Py_SET_TYPE(&ZstdCompressionChunkerIteratorType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionChunkerIteratorType) < 0) {
+    ZstdCompressionChunkerIteratorType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionChunkerIteratorSpec);
+    if (PyType_Ready(ZstdCompressionChunkerIteratorType) < 0) {
         return;
     }
 

--- a/c-ext/compressiondict.c
+++ b/c-ext/compressiondict.c
@@ -237,7 +237,7 @@ ZstdCompressionDict_precompute_compress(ZstdCompressionDict *self,
 
     if (!PyArg_ParseTupleAndKeywords(
             args, kwargs, "|iO!:precompute_compress", kwlist, &level,
-            &ZstdCompressionParametersType, &compressionParams)) {
+            ZstdCompressionParametersType, &compressionParams)) {
         return NULL;
     }
 

--- a/c-ext/compressiondict.c
+++ b/c-ext/compressiondict.c
@@ -124,7 +124,7 @@ ZstdCompressionDict *train_dictionary(PyObject *self, PyObject *args,
         goto finally;
     }
 
-    result = PyObject_New(ZstdCompressionDict, &ZstdCompressionDictType);
+    result = PyObject_New(ZstdCompressionDict, ZstdCompressionDictType);
     if (!result) {
         PyMem_Free(dict);
         goto finally;
@@ -315,64 +315,34 @@ static Py_ssize_t ZstdCompressionDict_length(ZstdCompressionDict *self) {
     return self->dictSize;
 }
 
-static PySequenceMethods ZstdCompressionDict_sq = {
-    (lenfunc)ZstdCompressionDict_length, /* sq_length */
-    0,                                   /* sq_concat */
-    0,                                   /* sq_repeat */
-    0,                                   /* sq_item */
-    0,                                   /* sq_ass_item */
-    0,                                   /* sq_contains */
-    0,                                   /* sq_inplace_concat */
-    0                                    /* sq_inplace_repeat */
+PyType_Slot ZstdCompressionDictSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionDict_dealloc},
+    {Py_sq_length, ZstdCompressionDict_length},
+    {Py_tp_methods, ZstdCompressionDict_methods},
+    {Py_tp_members, ZstdCompressionDict_members},
+    {Py_tp_init, ZstdCompressionDict_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
-PyTypeObject ZstdCompressionDictType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressionDict", /* tp_name */
-    sizeof(ZstdCompressionDict),              /* tp_basicsize */
-    0,                                        /* tp_itemsize */
-    (destructor)ZstdCompressionDict_dealloc,  /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    &ZstdCompressionDict_sq,                  /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    0,                                        /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    ZstdCompressionDict_methods,              /* tp_methods */
-    ZstdCompressionDict_members,              /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    (initproc)ZstdCompressionDict_init,       /* tp_init */
-    0,                                        /* tp_alloc */
-    PyType_GenericNew,                        /* tp_new */
+PyType_Spec ZstdCompressionDictSpec = {
+    "zstd.ZstdCompressionDict",
+    sizeof(ZstdCompressionDict),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionDictSlots,
 };
+
+PyTypeObject *ZstdCompressionDictType;
 
 void compressiondict_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdCompressionDictType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionDictType) < 0) {
+    ZstdCompressionDictType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionDictSpec);
+    if (PyType_Ready(ZstdCompressionDictType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdCompressionDictType);
+    Py_INCREF((PyObject *)ZstdCompressionDictType);
     PyModule_AddObject(mod, "ZstdCompressionDict",
-                       (PyObject *)&ZstdCompressionDictType);
+                       (PyObject *)ZstdCompressionDictType);
 }

--- a/c-ext/compressionparams.c
+++ b/c-ext/compressionparams.c
@@ -351,7 +351,7 @@ CompressionParameters_from_level(PyObject *undef, PyObject *args,
     }
 
     result = PyObject_New(ZstdCompressionParametersObject,
-                          &ZstdCompressionParametersType);
+                          ZstdCompressionParametersType);
     if (!result) {
         goto cleanup;
     }
@@ -469,53 +469,33 @@ static PyGetSetDef ZstdCompressionParameters_getset[] = {
     GET_SET_ENTRY(ldm_hash_rate_log),
     {NULL}};
 
-PyTypeObject ZstdCompressionParametersType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "ZstdCompressionParameters", /* tp_name */
-    sizeof(ZstdCompressionParametersObject),       /* tp_basicsize */
-    0,                                             /* tp_itemsize */
-    (destructor)ZstdCompressionParameters_dealloc, /* tp_dealloc */
-    0,                                             /* tp_print */
-    0,                                             /* tp_getattr */
-    0,                                             /* tp_setattr */
-    0,                                             /* tp_compare */
-    0,                                             /* tp_repr */
-    0,                                             /* tp_as_number */
-    0,                                             /* tp_as_sequence */
-    0,                                             /* tp_as_mapping */
-    0,                                             /* tp_hash  */
-    0,                                             /* tp_call */
-    0,                                             /* tp_str */
-    0,                                             /* tp_getattro */
-    0,                                             /* tp_setattro */
-    0,                                             /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,      /* tp_flags */
-    0,                                             /* tp_doc */
-    0,                                             /* tp_traverse */
-    0,                                             /* tp_clear */
-    0,                                             /* tp_richcompare */
-    0,                                             /* tp_weaklistoffset */
-    0,                                             /* tp_iter */
-    0,                                             /* tp_iternext */
-    ZstdCompressionParameters_methods,             /* tp_methods */
-    0,                                             /* tp_members */
-    ZstdCompressionParameters_getset,              /* tp_getset */
-    0,                                             /* tp_base */
-    0,                                             /* tp_dict */
-    0,                                             /* tp_descr_get */
-    0,                                             /* tp_descr_set */
-    0,                                             /* tp_dictoffset */
-    (initproc)ZstdCompressionParameters_init,      /* tp_init */
-    0,                                             /* tp_alloc */
-    PyType_GenericNew,                             /* tp_new */
+PyType_Slot ZstdCompressionParametersSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionParameters_dealloc},
+    {Py_tp_methods, ZstdCompressionParameters_methods},
+    {Py_tp_getset, ZstdCompressionParameters_getset},
+    {Py_tp_init, ZstdCompressionParameters_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdCompressionParametersSpec = {
+    "zstd.ZstdCompressionParameters",
+    sizeof(ZstdCompressionParametersObject),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionParametersSlots,
+};
+
+PyTypeObject *ZstdCompressionParametersType;
+
 void compressionparams_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdCompressionParametersType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionParametersType) < 0) {
+    ZstdCompressionParametersType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionParametersSpec);
+    if (PyType_Ready(ZstdCompressionParametersType) < 0) {
         return;
     }
 
-    Py_INCREF(&ZstdCompressionParametersType);
+    Py_INCREF(ZstdCompressionParametersType);
     PyModule_AddObject(mod, "ZstdCompressionParameters",
-                       (PyObject *)&ZstdCompressionParametersType);
+                       (PyObject *)ZstdCompressionParametersType);
 }

--- a/c-ext/compressionreader.c
+++ b/c-ext/compressionreader.c
@@ -777,54 +777,36 @@ static PyMemberDef compressionreader_members[] = {
      "whether stream is closed"},
     {NULL}};
 
-PyTypeObject ZstdCompressionReaderType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressionReader", /* tp_name */
-    sizeof(ZstdCompressionReader),         /* tp_basicsize */
-    0,                                     /* tp_itemsize */
-    (destructor)compressionreader_dealloc, /* tp_dealloc */
-    0,                                     /* tp_print */
-    0,                                     /* tp_getattr */
-    0,                                     /* tp_setattr */
-    0,                                     /* tp_compare */
-    0,                                     /* tp_repr */
-    0,                                     /* tp_as_number */
-    0,                                     /* tp_as_sequence */
-    0,                                     /* tp_as_mapping */
-    0,                                     /* tp_hash */
-    0,                                     /* tp_call */
-    0,                                     /* tp_str */
-    0,                                     /* tp_getattro */
-    0,                                     /* tp_setattro */
-    0,                                     /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                    /* tp_flags */
-    0,                                     /* tp_doc */
-    0,                                     /* tp_traverse */
-    0,                                     /* tp_clear */
-    0,                                     /* tp_richcompare */
-    0,                                     /* tp_weaklistoffset */
-    compressionreader_iter,                /* tp_iter */
-    compressionreader_iternext,            /* tp_iternext */
-    compressionreader_methods,             /* tp_methods */
-    compressionreader_members,             /* tp_members */
-    0,                                     /* tp_getset */
-    0,                                     /* tp_base */
-    0,                                     /* tp_dict */
-    0,                                     /* tp_descr_get */
-    0,                                     /* tp_descr_set */
-    0,                                     /* tp_dictoffset */
-    0,                                     /* tp_init */
-    0,                                     /* tp_alloc */
-    PyType_GenericNew,                     /* tp_new */
+PyType_Slot ZstdCompressionReaderSlots[] = {
+    {Py_tp_dealloc, compressionreader_dealloc},
+    {Py_tp_iter, compressionreader_iter},
+    {Py_tp_iternext, compressionreader_iternext},
+    {Py_tp_methods, compressionreader_methods},
+    {Py_tp_members, compressionreader_members},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
+
+PyType_Spec ZstdCompressionReaderSpec = {
+    "zstd.ZstdCompressionReader",
+    sizeof(ZstdCompressionReader),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    ZstdCompressionReaderSlots,
+};
+
+PyTypeObject *ZstdCompressionReaderType;
 
 void compressionreader_module_init(PyObject *mod) {
     /* TODO make reader a sub-class of io.RawIOBase */
 
-    Py_SET_TYPE(&ZstdCompressionReaderType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionReaderType) < 0) {
+    ZstdCompressionReaderType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionReaderSpec);
+    if (PyType_Ready(ZstdCompressionReaderType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdCompressionReaderType);
-    PyModule_AddObject(mod, "ZstdCompressionReader", (PyObject *)&ZstdCompressionReaderType);
+    Py_INCREF((PyObject *)ZstdCompressionReaderType);
+    PyModule_AddObject(mod, "ZstdCompressionReader",
+                       (PyObject *)ZstdCompressionReaderType);
 }

--- a/c-ext/compressionwriter.c
+++ b/c-ext/compressionwriter.c
@@ -319,52 +319,34 @@ static PyMemberDef ZstdCompressionWriter_members[] = {
     {"closed", T_BOOL, offsetof(ZstdCompressionWriter, closed), READONLY, NULL},
     {NULL}};
 
-PyTypeObject ZstdCompressionWriterType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressionWriter", /* tp_name */
-    sizeof(ZstdCompressionWriter),             /* tp_basicsize */
-    0,                                         /* tp_itemsize */
-    (destructor)ZstdCompressionWriter_dealloc, /* tp_dealloc */
-    0,                                         /* tp_print */
-    0,                                         /* tp_getattr */
-    0,                                         /* tp_setattr */
-    0,                                         /* tp_compare */
-    0,                                         /* tp_repr */
-    0,                                         /* tp_as_number */
-    0,                                         /* tp_as_sequence */
-    0,                                         /* tp_as_mapping */
-    0,                                         /* tp_hash */
-    0,                                         /* tp_call */
-    0,                                         /* tp_str */
-    0,                                         /* tp_getattro */
-    0,                                         /* tp_setattro */
-    0,                                         /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags */
-    0,                                         /* tp_doc */
-    0,                                         /* tp_traverse */
-    0,                                         /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    ZstdCompressionWriter_iter,                /* tp_iter */
-    ZstdCompressionWriter_iternext,            /* tp_iternext */
-    ZstdCompressionWriter_methods,             /* tp_methods */
-    ZstdCompressionWriter_members,             /* tp_members */
-    0,                                         /* tp_getset */
-    0,                                         /* tp_base */
-    0,                                         /* tp_dict */
-    0,                                         /* tp_descr_get */
-    0,                                         /* tp_descr_set */
-    0,                                         /* tp_dictoffset */
-    0,                                         /* tp_init */
-    0,                                         /* tp_alloc */
-    PyType_GenericNew,                         /* tp_new */
+PyType_Slot ZstdCompressionWriterSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionWriter_dealloc},
+    {Py_tp_iter, ZstdCompressionWriter_iter},
+    {Py_tp_iternext, ZstdCompressionWriter_iternext},
+    {Py_tp_methods, ZstdCompressionWriter_methods},
+    {Py_tp_members, ZstdCompressionWriter_members},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdCompressionWriterSpec = {
+    "zstd.ZstdCompressionWriter",
+    sizeof(ZstdCompressionWriter),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionWriterSlots,
+};
+
+PyTypeObject *ZstdCompressionWriterType;
+
 void compressionwriter_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdCompressionWriterType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionWriterType) < 0) {
+    ZstdCompressionWriterType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionWriterSpec);
+    if (PyType_Ready(ZstdCompressionWriterType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdCompressionWriterType);
-    PyModule_AddObject(mod, "ZstdCompressionWriter", (PyObject *)&ZstdCompressionWriterType);
+    Py_INCREF((PyObject *)ZstdCompressionWriterType);
+    PyModule_AddObject(mod, "ZstdCompressionWriter",
+                       (PyObject *)ZstdCompressionWriterType);
 }

--- a/c-ext/compressobj.c
+++ b/c-ext/compressobj.c
@@ -194,49 +194,27 @@ static PyMethodDef ZstdCompressionObj_methods[] = {
      METH_VARARGS | METH_KEYWORDS, PyDoc_STR("finish compression operation")},
     {NULL, NULL}};
 
-PyTypeObject ZstdCompressionObjType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressionObj", /* tp_name */
-    sizeof(ZstdCompressionObj),                               /* tp_basicsize */
-    0,                                                        /* tp_itemsize */
-    (destructor)ZstdCompressionObj_dealloc,                   /* tp_dealloc */
-    0,                                                        /* tp_print */
-    0,                                                        /* tp_getattr */
-    0,                                                        /* tp_setattr */
-    0,                                                        /* tp_compare */
-    0,                                                        /* tp_repr */
-    0,                                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    0,                                        /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    ZstdCompressionObj_methods,               /* tp_methods */
-    0,                                        /* tp_members */
-    0,                                        /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    PyType_GenericNew,                        /* tp_new */
+PyType_Slot ZstdCompressionObjSlots[] = {
+    {Py_tp_dealloc, ZstdCompressionObj_dealloc},
+    {Py_tp_methods, ZstdCompressionObj_methods},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdCompressionObjSpec = {
+    "zstd.ZstdCompressionObj",
+    sizeof(ZstdCompressionObj),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressionObjSlots,
+};
+
+PyTypeObject *ZstdCompressionObjType;
+
 void compressobj_module_init(PyObject *module) {
-    Py_SET_TYPE(&ZstdCompressionObjType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressionObjType) < 0) {
+    ZstdCompressionObjType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressionObjSpec);
+    if (PyType_Ready(ZstdCompressionObjType) < 0) {
         return;
     }
 }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -1298,7 +1298,7 @@ compress_from_datasources(ZstdCompressor *compressor, DataSources *sources,
     }
 
     result = (ZstdBufferWithSegmentsCollection *)PyObject_CallObject(
-        (PyObject *)&ZstdBufferWithSegmentsCollectionType, segmentsArg);
+        (PyObject *)ZstdBufferWithSegmentsCollectionType, segmentsArg);
 
 finally:
     Py_CLEAR(segmentsArg);
@@ -1392,7 +1392,7 @@ ZstdCompressor_multi_compress_to_buffer(ZstdCompressor *self, PyObject *args,
 
         sources.sourcesSize = buffer->segmentCount;
     }
-    else if (PyObject_TypeCheck(data, &ZstdBufferWithSegmentsCollectionType)) {
+    else if (PyObject_TypeCheck(data, ZstdBufferWithSegmentsCollectionType)) {
         Py_ssize_t j;
         Py_ssize_t offset = 0;
         ZstdBufferWithSegments *buffer;

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -126,7 +126,7 @@ static int ZstdCompressor_init(ZstdCompressor *self, PyObject *args,
             dict = NULL;
         }
         else if (!PyObject_IsInstance(dict,
-                                      (PyObject *)&ZstdCompressionDictType)) {
+                                      (PyObject *)ZstdCompressionDictType)) {
             PyErr_Format(PyExc_TypeError,
                          "dict_data must be zstd.ZstdCompressionDict");
             return -1;

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -634,7 +634,7 @@ static ZstdCompressorIterator *ZstdCompressor_read_to_iter(ZstdCompressor *self,
     }
 
     result = (ZstdCompressorIterator *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressorIteratorType, NULL);
+        (PyObject *)ZstdCompressorIteratorType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -455,7 +455,7 @@ static ZstdCompressionReader *ZstdCompressor_stream_reader(ZstdCompressor *self,
     }
 
     result = (ZstdCompressionReader *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionReaderType, NULL);
+        (PyObject *)ZstdCompressionReaderType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -1366,7 +1366,7 @@ ZstdCompressor_multi_compress_to_buffer(ZstdCompressor *self, PyObject *args,
         threads = 1;
     }
 
-    if (PyObject_TypeCheck(data, &ZstdBufferWithSegmentsType)) {
+    if (PyObject_TypeCheck(data, ZstdBufferWithSegmentsType)) {
         ZstdBufferWithSegments *buffer = (ZstdBufferWithSegments *)data;
 
         sources.sources =

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -1528,52 +1528,30 @@ static PyMethodDef ZstdCompressor_methods[] = {
      METH_NOARGS, NULL},
     {NULL, NULL}};
 
-PyTypeObject ZstdCompressorType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressor", /* tp_name */
-    sizeof(ZstdCompressor),                               /* tp_basicsize */
-    0,                                                    /* tp_itemsize */
-    (destructor)ZstdCompressor_dealloc,                   /* tp_dealloc */
-    0,                                                    /* tp_print */
-    0,                                                    /* tp_getattr */
-    0,                                                    /* tp_setattr */
-    0,                                                    /* tp_compare */
-    0,                                                    /* tp_repr */
-    0,                                                    /* tp_as_number */
-    0,                                                    /* tp_as_sequence */
-    0,                                                    /* tp_as_mapping */
-    0,                                                    /* tp_hash */
-    0,                                                    /* tp_call */
-    0,                                                    /* tp_str */
-    0,                                                    /* tp_getattro */
-    0,                                                    /* tp_setattro */
-    0,                                                    /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,             /* tp_flags */
-    0,                                                    /* tp_doc */
-    0,                                                    /* tp_traverse */
-    0,                                                    /* tp_clear */
-    0,                                                    /* tp_richcompare */
-    0,                             /* tp_weaklistoffset */
-    0,                             /* tp_iter */
-    0,                             /* tp_iternext */
-    ZstdCompressor_methods,        /* tp_methods */
-    0,                             /* tp_members */
-    0,                             /* tp_getset */
-    0,                             /* tp_base */
-    0,                             /* tp_dict */
-    0,                             /* tp_descr_get */
-    0,                             /* tp_descr_set */
-    0,                             /* tp_dictoffset */
-    (initproc)ZstdCompressor_init, /* tp_init */
-    0,                             /* tp_alloc */
-    PyType_GenericNew,             /* tp_new */
+PyType_Slot ZstdCompressorSlots[] = {
+    {Py_tp_dealloc, ZstdCompressor_dealloc},
+    {Py_tp_methods, ZstdCompressor_methods},
+    {Py_tp_init, ZstdCompressor_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdCompressorSpec = {
+    "zstd.ZstdCompressor",
+    sizeof(ZstdCompressor),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressorSlots,
+};
+
+PyTypeObject *ZstdCompressorType;
+
 void compressor_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdCompressorType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressorType) < 0) {
+    ZstdCompressorType = (PyTypeObject *)PyType_FromSpec(&ZstdCompressorSpec);
+    if (PyType_Ready(ZstdCompressorType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdCompressorType);
-    PyModule_AddObject(mod, "ZstdCompressor", (PyObject *)&ZstdCompressorType);
+    Py_INCREF((PyObject *)ZstdCompressorType);
+    PyModule_AddObject(mod, "ZstdCompressor", (PyObject *)ZstdCompressorType);
 }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -780,7 +780,7 @@ ZstdCompressor_chunker(ZstdCompressor *self, PyObject *args, PyObject *kwargs) {
     }
 
     chunker = (ZstdCompressionChunker *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionChunkerType, NULL);
+        (PyObject *)ZstdCompressionChunkerType, NULL);
     if (!chunker) {
         return NULL;
     }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -598,7 +598,7 @@ static ZstdCompressionObj *ZstdCompressor_compressobj(ZstdCompressor *self,
     }
 
     result = (ZstdCompressionObj *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionObjType, NULL);
+        (PyObject *)ZstdCompressionObjType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -723,7 +723,7 @@ static ZstdCompressionWriter *ZstdCompressor_stream_writer(ZstdCompressor *self,
     }
 
     result = (ZstdCompressionWriter *)PyObject_CallObject(
-        (PyObject *)&ZstdCompressionWriterType, NULL);
+        (PyObject *)ZstdCompressionWriterType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/compressor.c
+++ b/c-ext/compressor.c
@@ -138,7 +138,7 @@ static int ZstdCompressor_init(ZstdCompressor *self, PyObject *args,
             params = NULL;
         }
         else if (!PyObject_IsInstance(
-                     params, (PyObject *)&ZstdCompressionParametersType)) {
+                     params, (PyObject *)ZstdCompressionParametersType)) {
             PyErr_Format(
                 PyExc_TypeError,
                 "compression_params must be zstd.ZstdCompressionParameters");

--- a/c-ext/compressoriterator.c
+++ b/c-ext/compressoriterator.c
@@ -185,49 +185,28 @@ feedcompressor:
     return chunk;
 }
 
-PyTypeObject ZstdCompressorIteratorType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdCompressorIterator", /* tp_name */
-    sizeof(ZstdCompressorIterator),                /* tp_basicsize */
-    0,                                             /* tp_itemsize */
-    (destructor)ZstdCompressorIterator_dealloc,    /* tp_dealloc */
-    0,                                             /* tp_print */
-    0,                                             /* tp_getattr */
-    0,                                             /* tp_setattr */
-    0,                                             /* tp_compare */
-    0,                                             /* tp_repr */
-    0,                                             /* tp_as_number */
-    0,                                             /* tp_as_sequence */
-    0,                                             /* tp_as_mapping */
-    0,                                             /* tp_hash */
-    0,                                             /* tp_call */
-    0,                                             /* tp_str */
-    0,                                             /* tp_getattro */
-    0,                                             /* tp_setattro */
-    0,                                             /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,      /* tp_flags */
-    0,                                             /* tp_doc */
-    0,                                             /* tp_traverse */
-    0,                                             /* tp_clear */
-    0,                                             /* tp_richcompare */
-    0,                                             /* tp_weaklistoffset */
-    ZstdCompressorIterator_iter,                   /* tp_iter */
-    (iternextfunc)ZstdCompressorIterator_iternext, /* tp_iternext */
-    0,                                             /* tp_methods */
-    0,                                             /* tp_members */
-    0,                                             /* tp_getset */
-    0,                                             /* tp_base */
-    0,                                             /* tp_dict */
-    0,                                             /* tp_descr_get */
-    0,                                             /* tp_descr_set */
-    0,                                             /* tp_dictoffset */
-    0,                                             /* tp_init */
-    0,                                             /* tp_alloc */
-    PyType_GenericNew,                             /* tp_new */
+PyType_Slot ZstdCompressorIteratorSlots[] = {
+    {Py_tp_dealloc, ZstdCompressorIterator_dealloc},
+    {Py_tp_iter, ZstdCompressorIterator_iter},
+    {Py_tp_iternext, ZstdCompressorIterator_iternext},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdCompressorIteratorSpec = {
+    "zstd.ZstdCompressorIterator",
+    sizeof(ZstdCompressorIterator),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdCompressorIteratorSlots,
+};
+
+PyTypeObject *ZstdCompressorIteratorType;
+
 void compressoriterator_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdCompressorIteratorType, &PyType_Type);
-    if (PyType_Ready(&ZstdCompressorIteratorType) < 0) {
+    ZstdCompressorIteratorType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdCompressorIteratorSpec);
+    if (PyType_Ready(ZstdCompressorIteratorType) < 0) {
         return;
     }
 }

--- a/c-ext/decompressionreader.c
+++ b/c-ext/decompressionreader.c
@@ -745,54 +745,36 @@ static PyMemberDef decompressionreader_members[] = {
      "whether stream is closed"},
     {NULL}};
 
-PyTypeObject ZstdDecompressionReaderType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdDecompressionReader", /* tp_name */
-    sizeof(ZstdDecompressionReader),         /* tp_basicsize */
-    0,                                       /* tp_itemsize */
-    (destructor)decompressionreader_dealloc, /* tp_dealloc */
-    0,                                       /* tp_print */
-    0,                                       /* tp_getattr */
-    0,                                       /* tp_setattr */
-    0,                                       /* tp_compare */
-    0,                                       /* tp_repr */
-    0,                                       /* tp_as_number */
-    0,                                       /* tp_as_sequence */
-    0,                                       /* tp_as_mapping */
-    0,                                       /* tp_hash */
-    0,                                       /* tp_call */
-    0,                                       /* tp_str */
-    0,                                       /* tp_getattro */
-    0,                                       /* tp_setattro */
-    0,                                       /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                      /* tp_flags */
-    0,                                       /* tp_doc */
-    0,                                       /* tp_traverse */
-    0,                                       /* tp_clear */
-    0,                                       /* tp_richcompare */
-    0,                                       /* tp_weaklistoffset */
-    decompressionreader_iter,                /* tp_iter */
-    decompressionreader_iternext,            /* tp_iternext */
-    decompressionreader_methods,             /* tp_methods */
-    decompressionreader_members,             /* tp_members */
-    0,                                       /* tp_getset */
-    0,                                       /* tp_base */
-    0,                                       /* tp_dict */
-    0,                                       /* tp_descr_get */
-    0,                                       /* tp_descr_set */
-    0,                                       /* tp_dictoffset */
-    0,                                       /* tp_init */
-    0,                                       /* tp_alloc */
-    PyType_GenericNew,                       /* tp_new */
+PyType_Slot ZstdDecompressionReaderSlots[] = {
+    {Py_tp_dealloc, decompressionreader_dealloc},
+    {Py_tp_iter, decompressionreader_iter},
+    {Py_tp_iternext, decompressionreader_iternext},
+    {Py_tp_methods, decompressionreader_methods},
+    {Py_tp_members, decompressionreader_members},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
+
+PyType_Spec ZstdDecompressionReaderSpec = {
+    "zstd.ZstdDecompressionReader",
+    sizeof(ZstdDecompressionReader),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    ZstdDecompressionReaderSlots,
+};
+
+PyTypeObject *ZstdDecompressionReaderType;
 
 void decompressionreader_module_init(PyObject *mod) {
     /* TODO make reader a sub-class of io.RawIOBase */
 
-    Py_SET_TYPE(&ZstdDecompressionReaderType, &PyType_Type);
-    if (PyType_Ready(&ZstdDecompressionReaderType) < 0) {
+    ZstdDecompressionReaderType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdDecompressionReaderSpec);
+    if (PyType_Ready(ZstdDecompressionReaderType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdDecompressionReaderType);
-    PyModule_AddObject(mod, "ZstdDecompressionReader", (PyObject *)&ZstdDecompressionReaderType);
+    Py_INCREF((PyObject *)ZstdDecompressionReaderType);
+    PyModule_AddObject(mod, "ZstdDecompressionReader",
+                       (PyObject *)ZstdDecompressionReaderType);
 }

--- a/c-ext/decompressionwriter.c
+++ b/c-ext/decompressionwriter.c
@@ -240,52 +240,34 @@ static PyMemberDef ZstdDecompressionWriter_members[] = {
      NULL},
     {NULL}};
 
-PyTypeObject ZstdDecompressionWriterType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdDecompressionWriter", /* tp_name */
-    sizeof(ZstdDecompressionWriter),             /* tp_basicsize */
-    0,                                           /* tp_itemsize */
-    (destructor)ZstdDecompressionWriter_dealloc, /* tp_dealloc */
-    0,                                           /* tp_print */
-    0,                                           /* tp_getattr */
-    0,                                           /* tp_setattr */
-    0,                                           /* tp_compare */
-    0,                                           /* tp_repr */
-    0,                                           /* tp_as_number */
-    0,                                           /* tp_as_sequence */
-    0,                                           /* tp_as_mapping */
-    0,                                           /* tp_hash */
-    0,                                           /* tp_call */
-    0,                                           /* tp_str */
-    0,                                           /* tp_getattro */
-    0,                                           /* tp_setattro */
-    0,                                           /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,    /* tp_flags */
-    0,                                           /* tp_doc */
-    0,                                           /* tp_traverse */
-    0,                                           /* tp_clear */
-    0,                                           /* tp_richcompare */
-    0,                                           /* tp_weaklistoffset */
-    ZstdDecompressionWriter_iter,                /* tp_iter */
-    ZstdDecompressionWriter_iternext,            /* tp_iternext */
-    ZstdDecompressionWriter_methods,             /* tp_methods */
-    ZstdDecompressionWriter_members,             /* tp_members */
-    0,                                           /* tp_getset */
-    0,                                           /* tp_base */
-    0,                                           /* tp_dict */
-    0,                                           /* tp_descr_get */
-    0,                                           /* tp_descr_set */
-    0,                                           /* tp_dictoffset */
-    0,                                           /* tp_init */
-    0,                                           /* tp_alloc */
-    PyType_GenericNew,                           /* tp_new */
+PyType_Slot ZstdDecompressionWriterSlots[] = {
+    {Py_tp_dealloc, ZstdDecompressionWriter_dealloc},
+    {Py_tp_iter, ZstdDecompressionWriter_iter},
+    {Py_tp_iternext, ZstdDecompressionWriter_iternext},
+    {Py_tp_methods, ZstdDecompressionWriter_methods},
+    {Py_tp_members, ZstdDecompressionWriter_members},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdDecompressionWriterSpec = {
+    "zstd.ZstdDecompressionWriter",
+    sizeof(ZstdDecompressionWriter),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdDecompressionWriterSlots,
+};
+
+PyTypeObject *ZstdDecompressionWriterType;
+
 void decompressionwriter_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdDecompressionWriterType, &PyType_Type);
-    if (PyType_Ready(&ZstdDecompressionWriterType) < 0) {
+    ZstdDecompressionWriterType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdDecompressionWriterSpec);
+    if (PyType_Ready(ZstdDecompressionWriterType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdDecompressionWriterType);
-    PyModule_AddObject(mod, "ZstdDecompressionWriter", (PyObject *)&ZstdDecompressionWriterType);
+    Py_INCREF((PyObject *)ZstdDecompressionWriterType);
+    PyModule_AddObject(mod, "ZstdDecompressionWriter",
+                       (PyObject *)ZstdDecompressionWriterType);
 }

--- a/c-ext/decompressobj.c
+++ b/c-ext/decompressobj.c
@@ -174,49 +174,28 @@ static PyGetSetDef DecompressionObj_getset[] = {
     {"eof", DecompressionObj_eof, NULL, NULL, NULL },
     {NULL}};
 
-PyTypeObject ZstdDecompressionObjType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdDecompressionObj", /* tp_name */
-    sizeof(ZstdDecompressionObj),             /* tp_basicsize */
-    0,                                        /* tp_itemsize */
-    (destructor)DecompressionObj_dealloc,     /* tp_dealloc */
-    0,                                        /* tp_print */
-    0,                                        /* tp_getattr */
-    0,                                        /* tp_setattr */
-    0,                                        /* tp_compare */
-    0,                                        /* tp_repr */
-    0,                                        /* tp_as_number */
-    0,                                        /* tp_as_sequence */
-    0,                                        /* tp_as_mapping */
-    0,                                        /* tp_hash */
-    0,                                        /* tp_call */
-    0,                                        /* tp_str */
-    0,                                        /* tp_getattro */
-    0,                                        /* tp_setattro */
-    0,                                        /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    0,                                        /* tp_doc */
-    0,                                        /* tp_traverse */
-    0,                                        /* tp_clear */
-    0,                                        /* tp_richcompare */
-    0,                                        /* tp_weaklistoffset */
-    0,                                        /* tp_iter */
-    0,                                        /* tp_iternext */
-    DecompressionObj_methods,                 /* tp_methods */
-    0,                                        /* tp_members */
-    DecompressionObj_getset,                  /* tp_getset */
-    0,                                        /* tp_base */
-    0,                                        /* tp_dict */
-    0,                                        /* tp_descr_get */
-    0,                                        /* tp_descr_set */
-    0,                                        /* tp_dictoffset */
-    0,                                        /* tp_init */
-    0,                                        /* tp_alloc */
-    PyType_GenericNew,                        /* tp_new */
+PyType_Slot ZstdDecompressionObjSlots[] = {
+    {Py_tp_dealloc, DecompressionObj_dealloc},
+    {Py_tp_methods, DecompressionObj_methods},
+    {Py_tp_getset, DecompressionObj_getset},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdDecompressionObjSpec = {
+    "zstd.ZstdDecompressionObj",
+    sizeof(ZstdDecompressionObj),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdDecompressionObjSlots,
+};
+
+PyTypeObject *ZstdDecompressionObjType;
+
 void decompressobj_module_init(PyObject *module) {
-    Py_SET_TYPE(&ZstdDecompressionObjType, &PyType_Type);
-    if (PyType_Ready(&ZstdDecompressionObjType) < 0) {
+    ZstdDecompressionObjType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdDecompressionObjSpec);
+    if (PyType_Ready(ZstdDecompressionObjType) < 0) {
         return;
     }
 }

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -413,7 +413,7 @@ static ZstdDecompressionObj *Decompressor_decompressobj(ZstdDecompressor *self,
     }
 
     result = (ZstdDecompressionObj *)PyObject_CallObject(
-        (PyObject *)&ZstdDecompressionObjType, NULL);
+        (PyObject *)ZstdDecompressionObjType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -454,7 +454,7 @@ Decompressor_read_to_iter(ZstdDecompressor *self, PyObject *args,
     }
 
     result = (ZstdDecompressorIterator *)PyObject_CallObject(
-        (PyObject *)&ZstdDecompressorIteratorType, NULL);
+        (PyObject *)ZstdDecompressorIteratorType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -591,7 +591,7 @@ Decompressor_stream_writer(ZstdDecompressor *self, PyObject *args,
     }
 
     result = (ZstdDecompressionWriter *)PyObject_CallObject(
-        (PyObject *)&ZstdDecompressionWriterType, NULL);
+        (PyObject *)ZstdDecompressionWriterType, NULL);
     if (!result) {
         return NULL;
     }

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -1492,7 +1492,7 @@ Decompressor_multi_decompress_to_buffer(ZstdDecompressor *self, PyObject *args,
         threads = 1;
     }
 
-    if (PyObject_TypeCheck(frames, &ZstdBufferWithSegmentsType)) {
+    if (PyObject_TypeCheck(frames, ZstdBufferWithSegmentsType)) {
         ZstdBufferWithSegments *buffer = (ZstdBufferWithSegments *)frames;
         frameCount = buffer->segmentCount;
 

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -1415,7 +1415,7 @@ decompress_from_framesources(ZstdDecompressor *decompressor,
     }
 
     result = (ZstdBufferWithSegmentsCollection *)PyObject_CallObject(
-        (PyObject *)&ZstdBufferWithSegmentsCollectionType, resultArg);
+        (PyObject *)ZstdBufferWithSegmentsCollectionType, resultArg);
 
 finally:
     Py_CLEAR(resultArg);
@@ -1551,8 +1551,7 @@ Decompressor_multi_decompress_to_buffer(ZstdDecompressor *self, PyObject *args,
             framePointers[i].destSize = (size_t)decompressedSize;
         }
     }
-    else if (PyObject_TypeCheck(frames,
-                                &ZstdBufferWithSegmentsCollectionType)) {
+    else if (PyObject_TypeCheck(frames, ZstdBufferWithSegmentsCollectionType)) {
         Py_ssize_t offset = 0;
         ZstdBufferWithSegments *buffer;
         ZstdBufferWithSegmentsCollection *collection =

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -76,7 +76,7 @@ static int Decompressor_init(ZstdDecompressor *self, PyObject *args,
             dict = NULL;
         }
         else if (!PyObject_IsInstance(dict,
-                                      (PyObject *)&ZstdCompressionDictType)) {
+                                      (PyObject *)ZstdCompressionDictType)) {
             PyErr_Format(PyExc_TypeError,
                          "dict_data must be zstd.ZstdCompressionDict");
             return -1;

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -1734,53 +1734,32 @@ static PyMethodDef Decompressor_methods[] = {
     {"memory_size", (PyCFunction)Decompressor_memory_size, METH_NOARGS, NULL},
     {NULL, NULL}};
 
-PyTypeObject ZstdDecompressorType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "zstd.ZstdDecompressor", /* tp_name */
-    sizeof(ZstdDecompressor),                               /* tp_basicsize */
-    0,                                                      /* tp_itemsize */
-    (destructor)Decompressor_dealloc,                       /* tp_dealloc */
-    0,                                                      /* tp_print */
-    0,                                                      /* tp_getattr */
-    0,                                                      /* tp_setattr */
-    0,                                                      /* tp_compare */
-    0,                                                      /* tp_repr */
-    0,                                                      /* tp_as_number */
-    0,                                                      /* tp_as_sequence */
-    0,                                                      /* tp_as_mapping */
-    0,                                                      /* tp_hash */
-    0,                                                      /* tp_call */
-    0,                                                      /* tp_str */
-    0,                                                      /* tp_getattro */
-    0,                                                      /* tp_setattro */
-    0,                                                      /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,               /* tp_flags */
-    0,                                                      /* tp_doc */
-    0,                                                      /* tp_traverse */
-    0,                                                      /* tp_clear */
-    0,                                                      /* tp_richcompare */
-    0,                           /* tp_weaklistoffset */
-    0,                           /* tp_iter */
-    0,                           /* tp_iternext */
-    Decompressor_methods,        /* tp_methods */
-    0,                           /* tp_members */
-    0,                           /* tp_getset */
-    0,                           /* tp_base */
-    0,                           /* tp_dict */
-    0,                           /* tp_descr_get */
-    0,                           /* tp_descr_set */
-    0,                           /* tp_dictoffset */
-    (initproc)Decompressor_init, /* tp_init */
-    0,                           /* tp_alloc */
-    PyType_GenericNew,           /* tp_new */
+PyType_Slot ZstdDecompressorSlots[] = {
+    {Py_tp_dealloc, Decompressor_dealloc},
+    {Py_tp_methods, Decompressor_methods},
+    {Py_tp_init, Decompressor_init},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdDecompressorSpec = {
+    "zstd.ZstdDecompressor",
+    sizeof(ZstdDecompressor),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdDecompressorSlots,
+};
+
+PyTypeObject *ZstdDecompressorType;
+
 void decompressor_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdDecompressorType, &PyType_Type);
-    if (PyType_Ready(&ZstdDecompressorType) < 0) {
+    ZstdDecompressorType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdDecompressorSpec);
+    if (PyType_Ready(ZstdDecompressorType) < 0) {
         return;
     }
 
-    Py_INCREF((PyObject *)&ZstdDecompressorType);
+    Py_INCREF((PyObject *)ZstdDecompressorType);
     PyModule_AddObject(mod, "ZstdDecompressor",
-                       (PyObject *)&ZstdDecompressorType);
+                       (PyObject *)ZstdDecompressorType);
 }

--- a/c-ext/decompressor.c
+++ b/c-ext/decompressor.c
@@ -526,7 +526,7 @@ Decompressor_stream_reader(ZstdDecompressor *self, PyObject *args,
     }
 
     result = (ZstdDecompressionReader *)PyObject_CallObject(
-        (PyObject *)&ZstdDecompressionReaderType, NULL);
+        (PyObject *)ZstdDecompressionReaderType, NULL);
     if (NULL == result) {
         return NULL;
     }

--- a/c-ext/decompressoriterator.c
+++ b/c-ext/decompressoriterator.c
@@ -201,50 +201,28 @@ read_from_source:
     return NULL;
 }
 
-PyTypeObject ZstdDecompressorIteratorType = {
-    PyVarObject_HEAD_INIT(NULL,
-                          0) "zstd.ZstdDecompressorIterator", /* tp_name */
-    sizeof(ZstdDecompressorIterator),                         /* tp_basicsize */
-    0,                                                        /* tp_itemsize */
-    (destructor)ZstdDecompressorIterator_dealloc,             /* tp_dealloc */
-    0,                                                        /* tp_print */
-    0,                                                        /* tp_getattr */
-    0,                                                        /* tp_setattr */
-    0,                                                        /* tp_compare */
-    0,                                                        /* tp_repr */
-    0,                                                        /* tp_as_number */
-    0,                                               /* tp_as_sequence */
-    0,                                               /* tp_as_mapping */
-    0,                                               /* tp_hash */
-    0,                                               /* tp_call */
-    0,                                               /* tp_str */
-    0,                                               /* tp_getattro */
-    0,                                               /* tp_setattro */
-    0,                                               /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,        /* tp_flags */
-    0,                                               /* tp_doc */
-    0,                                               /* tp_traverse */
-    0,                                               /* tp_clear */
-    0,                                               /* tp_richcompare */
-    0,                                               /* tp_weaklistoffset */
-    ZstdDecompressorIterator_iter,                   /* tp_iter */
-    (iternextfunc)ZstdDecompressorIterator_iternext, /* tp_iternext */
-    0,                                               /* tp_methods */
-    0,                                               /* tp_members */
-    0,                                               /* tp_getset */
-    0,                                               /* tp_base */
-    0,                                               /* tp_dict */
-    0,                                               /* tp_descr_get */
-    0,                                               /* tp_descr_set */
-    0,                                               /* tp_dictoffset */
-    0,                                               /* tp_init */
-    0,                                               /* tp_alloc */
-    PyType_GenericNew,                               /* tp_new */
+PyType_Slot ZstdDecompressorIteratorSlots[] = {
+    {Py_tp_dealloc, ZstdDecompressorIterator_dealloc},
+    {Py_tp_iter, ZstdDecompressorIterator_iter},
+    {Py_tp_iternext, ZstdDecompressorIterator_iternext},
+    {Py_tp_new, PyType_GenericNew},
+    {0, NULL},
 };
 
+PyType_Spec ZstdDecompressorIteratorSpec = {
+    "zstd.ZstdDecompressorIterator",
+    sizeof(ZstdDecompressorIterator),
+    0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    ZstdDecompressorIteratorSlots,
+};
+
+PyTypeObject *ZstdDecompressorIteratorType;
+
 void decompressoriterator_module_init(PyObject *mod) {
-    Py_SET_TYPE(&ZstdDecompressorIteratorType, &PyType_Type);
-    if (PyType_Ready(&ZstdDecompressorIteratorType) < 0) {
+    ZstdDecompressorIteratorType =
+        (PyTypeObject *)PyType_FromSpec(&ZstdDecompressorIteratorSpec);
+    if (PyType_Ready(ZstdDecompressorIteratorType) < 0) {
         return;
     }
 }

--- a/c-ext/frameparams.c
+++ b/c-ext/frameparams.c
@@ -39,7 +39,7 @@ FrameParametersObject *get_frame_parameters(PyObject *self, PyObject *args,
         goto finally;
     }
 
-    result = PyObject_New(FrameParametersObject, &FrameParametersType);
+    result = PyObject_New(FrameParametersObject, FrameParametersType);
     if (!result) {
         goto finally;
     }
@@ -70,53 +70,28 @@ static PyMemberDef FrameParameters_members[] = {
      READONLY, "checksum flag"},
     {NULL}};
 
-PyTypeObject FrameParametersType = {
-    PyVarObject_HEAD_INIT(NULL, 0) "FrameParameters", /* tp_name */
-    sizeof(FrameParametersObject),                    /* tp_basicsize */
-    0,                                                /* tp_itemsize */
-    (destructor)FrameParameters_dealloc,              /* tp_dealloc */
-    0,                                                /* tp_print */
-    0,                                                /* tp_getattr */
-    0,                                                /* tp_setattr */
-    0,                                                /* tp_compare */
-    0,                                                /* tp_repr */
-    0,                                                /* tp_as_number */
-    0,                                                /* tp_as_sequence */
-    0,                                                /* tp_as_mapping */
-    0,                                                /* tp_hash  */
-    0,                                                /* tp_call */
-    0,                                                /* tp_str */
-    0,                                                /* tp_getattro */
-    0,                                                /* tp_setattro */
-    0,                                                /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,                               /* tp_flags */
-    0,                                                /* tp_doc */
-    0,                                                /* tp_traverse */
-    0,                                                /* tp_clear */
-    0,                                                /* tp_richcompare */
-    0,                                                /* tp_weaklistoffset */
-    0,                                                /* tp_iter */
-    0,                                                /* tp_iternext */
-    0,                                                /* tp_methods */
-    FrameParameters_members,                          /* tp_members */
-    0,                                                /* tp_getset */
-    0,                                                /* tp_base */
-    0,                                                /* tp_dict */
-    0,                                                /* tp_descr_get */
-    0,                                                /* tp_descr_set */
-    0,                                                /* tp_dictoffset */
-    0,                                                /* tp_init */
-    0,                                                /* tp_alloc */
-    0,                                                /* tp_new */
+PyType_Slot FrameParametersSlots[] = {
+    {Py_tp_dealloc, FrameParameters_dealloc},
+    {Py_tp_members, FrameParameters_members},
+    {0, NULL},
 };
 
+PyType_Spec FrameParametersSpec = {
+    "zstd.FrameParameters",
+    sizeof(FrameParametersObject),
+    0,
+    Py_TPFLAGS_DEFAULT,
+    FrameParametersSlots,
+};
+
+PyTypeObject *FrameParametersType;
+
 void frameparams_module_init(PyObject *mod) {
-    Py_SET_TYPE(&FrameParametersType, &PyType_Type);
-    if (PyType_Ready(&FrameParametersType) < 0) {
+    FrameParametersType = (PyTypeObject *)PyType_FromSpec(&FrameParametersSpec);
+    if (PyType_Ready(FrameParametersType) < 0) {
         return;
     }
 
-    Py_INCREF(&FrameParametersType);
-    PyModule_AddObject(mod, "FrameParameters",
-                       (PyObject *)&FrameParametersType);
+    Py_INCREF(FrameParametersType);
+    PyModule_AddObject(mod, "FrameParameters", (PyObject *)FrameParametersType);
 }

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -296,7 +296,7 @@ typedef struct {
     int finishedOutput;
 } ZstdDecompressorIterator;
 
-extern PyTypeObject ZstdDecompressorIteratorType;
+extern PyTypeObject *ZstdDecompressorIteratorType;
 
 typedef struct {
     int errored;

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -152,7 +152,7 @@ typedef struct {
     PyObject *readResult;
 } ZstdCompressorIterator;
 
-extern PyTypeObject ZstdCompressorIteratorType;
+extern PyTypeObject *ZstdCompressorIteratorType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -343,7 +343,7 @@ typedef struct {
     int useFree;
 } ZstdBufferWithSegments;
 
-extern PyTypeObject ZstdBufferWithSegmentsType;
+extern PyTypeObject *ZstdBufferWithSegmentsType;
 
 /**
  * An ordered collection of BufferWithSegments exposed as a squashed collection.

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -116,7 +116,7 @@ typedef struct {
     int finished;
 } ZstdCompressionObj;
 
-extern PyTypeObject ZstdCompressionObjType;
+extern PyTypeObject *ZstdCompressionObjType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -47,7 +47,7 @@ typedef struct {
     PyObject_HEAD ZSTD_CCtx_params *params;
 } ZstdCompressionParametersObject;
 
-extern PyTypeObject ZstdCompressionParametersType;
+extern PyTypeObject *ZstdCompressionParametersType;
 
 /*
    Represents a FrameParameters type.

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -187,7 +187,7 @@ typedef struct {
     size_t chunkSize;
 } ZstdCompressionChunker;
 
-extern PyTypeObject ZstdCompressionChunkerType;
+extern PyTypeObject *ZstdCompressionChunkerType;
 
 typedef enum {
     compressionchunker_mode_normal,

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -319,7 +319,7 @@ typedef struct {
     Py_ssize_t segmentCount;
 } ZstdBufferSegments;
 
-extern PyTypeObject ZstdBufferSegmentsType;
+extern PyTypeObject *ZstdBufferSegmentsType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -202,7 +202,7 @@ typedef struct {
     CompressionChunkerMode mode;
 } ZstdCompressionChunkerIterator;
 
-extern PyTypeObject ZstdCompressionChunkerIteratorType;
+extern PyTypeObject *ZstdCompressionChunkerIteratorType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -224,7 +224,7 @@ typedef struct {
     PyObject *unused_data;
 } ZstdDecompressionObj;
 
-extern PyTypeObject ZstdDecompressionObjType;
+extern PyTypeObject *ZstdDecompressionObjType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -277,7 +277,7 @@ typedef struct {
     int closefd;
 } ZstdDecompressionWriter;
 
-extern PyTypeObject ZstdDecompressionWriterType;
+extern PyTypeObject *ZstdDecompressionWriterType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -133,7 +133,7 @@ typedef struct {
     unsigned long long bytesCompressed;
 } ZstdCompressionWriter;
 
-extern PyTypeObject ZstdCompressionWriterType;
+extern PyTypeObject *ZstdCompressionWriterType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -61,7 +61,7 @@ typedef struct {
     char checksumFlag;
 } FrameParametersObject;
 
-extern PyTypeObject FrameParametersType;
+extern PyTypeObject *FrameParametersType;
 
 /*
    Represents a ZstdCompressionDict type.

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -106,7 +106,7 @@ typedef struct {
     ZSTD_CCtx_params *params;
 } ZstdCompressor;
 
-extern PyTypeObject ZstdCompressorType;
+extern PyTypeObject *ZstdCompressorType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -330,7 +330,7 @@ typedef struct {
     unsigned long long offset;
 } ZstdBufferSegment;
 
-extern PyTypeObject ZstdBufferSegmentType;
+extern PyTypeObject *ZstdBufferSegmentType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -213,7 +213,7 @@ typedef struct {
     ZSTD_format_e format;
 } ZstdDecompressor;
 
-extern PyTypeObject ZstdDecompressorType;
+extern PyTypeObject *ZstdDecompressorType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -262,7 +262,7 @@ typedef struct {
     int finishedOutput;
 } ZstdDecompressionReader;
 
-extern PyTypeObject ZstdDecompressionReaderType;
+extern PyTypeObject *ZstdDecompressionReaderType;
 
 typedef struct {
     PyObject_HEAD

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -87,7 +87,7 @@ typedef struct {
     ZSTD_DDict *ddict;
 } ZstdCompressionDict;
 
-extern PyTypeObject ZstdCompressionDictType;
+extern PyTypeObject *ZstdCompressionDictType;
 
 /*
    Represents a ZstdCompressor type.

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -366,7 +366,7 @@ typedef struct {
     Py_ssize_t *firstElements;
 } ZstdBufferWithSegmentsCollection;
 
-extern PyTypeObject ZstdBufferWithSegmentsCollectionType;
+extern PyTypeObject *ZstdBufferWithSegmentsCollectionType;
 
 int set_parameter(ZSTD_CCtx_params *params, ZSTD_cParameter param, int value);
 int set_parameters(ZSTD_CCtx_params *params,

--- a/c-ext/python-zstandard.h
+++ b/c-ext/python-zstandard.h
@@ -174,7 +174,7 @@ typedef struct {
     PyObject *readResult;
 } ZstdCompressionReader;
 
-extern PyTypeObject ZstdCompressionReaderType;
+extern PyTypeObject *ZstdCompressionReaderType;
 
 typedef struct {
     PyObject_HEAD


### PR DESCRIPTION
This is a first step towards possibly using the stable ABI.