### PR TITLE
use Py_REFCNT(obj) instead of obj->ob_refcnt (allows building in nogil)

### DIFF
--- a/c-ext/backend_c.c
+++ b/c-ext/backend_c.c
@@ -313,7 +313,7 @@ size_t roundpow2(size_t i) {
 int safe_pybytes_resize(PyObject **obj, Py_ssize_t size) {
     PyObject *tmp;
 
-    if ((*obj)->ob_refcnt == 1) {
+    if (Py_REFCNT(obj) == 1) {
         return _PyBytes_Resize(obj, size);
     }
 


### PR DESCRIPTION
here’s a suggestion from @colesbury:

> This looks like it needs to use `Py_REFCNT(obj)` instead of `obj->ob_refcnt`. The reference count field changed (it's now two fields in "nogil Python), so you can't access them directly. The Python docs now say to use `Py_REFCNT` instead of `->ob_refcnt` so maybe we can get this change upstreamed.
