### PR TITLE
build: fix building with modern setuptools backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ try:
 except ImportError:
     cffi = None
 
+sys.path.insert(0, ".")
+
 import setup_zstd
 
 SUPPORT_LEGACY = False


### PR DESCRIPTION
Set correct `sys.path` prior to importing `setup_zstd`, in order to fix building with the modern setuptools backend, i.e.:

```
* Getting build dependencies for wheel...
<string>:37: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
<string>:38: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/usr/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
    return hook(config_settings)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-mgz__6r4/lib/python3.12/site-packages/setuptools/build_meta.py", line 355, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-mgz__6r4/lib/python3.12/site-packages/setuptools/build_meta.py", line 325, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-mgz__6r4/lib/python3.12/site-packages/setuptools/build_meta.py", line 341, in run_setup
    exec(code, locals())
  File "<string>", line 49, in <module>
ModuleNotFoundError: No module named 'setup_zstd'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```