### PR TITLE
add explicit <unistd.h> include

### DIFF
--- a/c-ext/backend_c.c
+++ b/c-ext/backend_c.c
@@ -17,6 +17,8 @@
 
 #include <sys/sysctl.h>
 
+#elif defined(__linux__) && defined(HAVE_UNISTD_H)
+#include <unistd.h>
 #endif
 
 #include "python-zstandard.h"


### PR DESCRIPTION
This fixes the following compilation error with Python 3.13.0a1:
```
c-ext/backend_c.c:275:13: error: implicit declaration of function ‘sysconf’; did you mean ‘sscanf’? [-Werror=implicit-function-declaration]
  275 |     count = sysconf(_SC_NPROCESSORS_ONLN);
      |             ^~~~~~~
      |             sscanf
```

According to https://docs.python.org/3.13/whatsnew/3.13.html:

`Python.h` no longer includes the `<unistd.h>` standard header file. If needed, it should now be included explicitly.
For example, it provides the functions: `read()`, `write()`, `close()`, `isatty()`, `lseek()`, `getpid()`, `getcwd()`, `sysconf()` and `getpagesize()`. As a consequence, `_POSIX_SEMAPHORES` and `_POSIX_THREADS` macros are no longer defined by `Python.h`. The `HAVE_UNISTD_H` and `HAVE_PTHREAD_H` macros defined by `Python.h` can be used to decide if `<unistd.h>` and `<pthread.h>` header files can be included.

See https://github.com/python/cpython/pull/108783 .