### PR TITLE
Add top-level docs section for One-Shot APIs

### DIFF
--- a/docs/api_usage.rst
+++ b/docs/api_usage.rst
@@ -65,6 +65,7 @@ this is often not feasible.
 
 The *one-shot* APIs also perform all work as a single operation. So, if you
 feed it large input, it could take a long time for the function to return.
+See :ref:`one_shot_apis` for reference.
 
 The streaming APIs do not have the limitations of the simple API. But the
 price you pay for this flexibility is that they are more complex than a
@@ -145,5 +146,3 @@ example, the difference between *context* reuse and non-reuse for 100,000
 100 byte inputs will be significant (possibly over 10x faster to reuse contexts)
 whereas 10 100,000,000 byte inputs will be more similar in speed (because the
 time spent doing compression dwarfs time spent creating new *contexts*).
-
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ python-zstandard
    installing
    concepts
    api_usage
+   one_shot_api
    compressor
    decompressor
    multithreaded

--- a/docs/misc_apis.rst
+++ b/docs/misc_apis.rst
@@ -27,21 +27,6 @@ https://github.com/facebook/zstd/blob/master/doc/zstd_compression_format.md.
 
 .. autofunction:: zstandard.estimate_decompression_context_size
 
-``open()``
-==========
-
-.. autofunction:: zstandard.open
-
-``compress()``
-==============
-
-.. autofunction:: zstandard.compress
-
-``decompress()``
-================
-
-.. autofunction:: zstandard.decompress
-
 Constants
 =========
 

--- a/docs/one_shot_api.rst
+++ b/docs/one_shot_api.rst
@@ -1,0 +1,20 @@
+.. _one_shot_apis:
+
+=============
+One-Shot APIs
+=============
+
+``compress()``
+==============
+
+.. autofunction:: zstandard.compress
+
+``decompress()``
+================
+
+.. autofunction:: zstandard.decompress
+
+``open()``
+==========
+
+.. autofunction:: zstandard.open


### PR DESCRIPTION
I find the one-shot APIs (which are what I most commonly have cause to reach for) are slightly buried in the docs, on the second page of "Miscellaneous APIs": https://python-zstandard.readthedocs.io/en/latest/misc_apis.html