### PR TITLE
Fix doc backend_cffi.py

### DIFF
--- a/zstandard/backend_cffi.py
+++ b/zstandard/backend_cffi.py
@@ -2633,7 +2633,7 @@ class ZstdCompressionDict(object):
 
     Dictionaries have unique integer IDs. You can retrieve this ID via:
 
-    >>> dict_id = zstandard.dictionary_id(dict_data)
+    >>> dict_id = dict_data.dict_id()
 
     You can obtain the raw data in the dict (useful for persisting and constructing
     a ``ZstdCompressionDict`` later) via ``as_bytes()``:


### PR DESCRIPTION
Fix documentation. The way to fetch the dict id from a dictionary is `dict_data.dict_id()`. The function `zstanard.dictionary_id()` is not defined.