### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cffi==1.16.0",
+    "cffi==1.17.0.dev0",
     "setuptools==68.2.2",
     "wheel==0.41.2",
 ]


### PR DESCRIPTION
update cffi to `cffi==1.17.0.dev0`

To resolve issue for upgrading to Python 3.13.0b1