### PR TITLE
Bump `cffi` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cffi==1.16.0",
+    "cffi>1.16.0",
     "setuptools==68.2.2",
     "wheel==0.41.2",
 ]


### PR DESCRIPTION
This will ensure building with Python 3.13 works