### PR TITLE
setup: fix Python 3.13 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,10 @@ if sys.version_info[0:2] < (3, 8):
 # garbage collection pitfalls.
 MINIMUM_CFFI_VERSION = "1.11"
 
-# Need 1.17+ on 3.13 to avoid deprecated and removed APIs.
+# Need 1.17.0rc1+ on 3.13 to avoid deprecated and removed APIs:
+# https://github.com/python-cffi/cffi/releases/tag/v1.17.0rc1
 if sys.version_info[0:2] >= (3, 13):
-    MINIMUM_CFFI_VERSION = "1.17"
+    MINIMUM_CFFI_VERSION = "1.17.0rc1"
 
 try:
     import cffi


### PR DESCRIPTION
To install pre-release versions, a requirement specifier should include
pre-release version:
https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions

```
$ pip install 'cffi>=1.17'
Defaulting to user installation because normal site-packages is not writeable
ERROR: Ignored the following yanked versions: 1.0.2.post2
ERROR: Could not find a version that satisfies the requirement cffi>=1.17 (from versions: 0.1, 0.2, 0.2.1, 0.3, 0.4, 0.4.1, 0.4.2, 0.5, 0.6, 0.7, 0.7.1, 0.7.2, 0.8, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.8.6, 0.9.0, 0.9.1, 0.9.2, 1.0.0, 1.0.1, 1.0.3, 1.1.0, 1.1.1, 1.1.2, 1.2.0.post1, 1.2.1, 1.3.0, 1.3.1, 1.4.0, 1.4.1, 1.4.2, 1.5.0, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.2, 1.8.3, 1.9.0, 1.9.1, 1.10.0, 1.11.0, 1.11.1, 1.11.2, 1.11.3, 1.11.4, 1.11.5, 1.12.0, 1.12.1, 1.12.2, 1.12.3, 1.13.0, 1.13.1, 1.13.2, 1.14.0, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0rc1, 1.15.0rc2, 1.15.0, 1.15.1, 1.16.0rc1, 1.16.0rc2, 1.16.0, 1.17.0rc1)
ERROR: No matching distribution found for cffi>=1.17
$ pip install 'cffi>=1.17.0rc1'
Defaulting to user installation because normal site-packages is not writeable
Collecting cffi>=1.17.0rc1
  Downloading cffi-1.17.0rc1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Requirement already satisfied: pycparser in /usr/lib/python3.12/site-packages (from cffi>=1.17.0rc1) (2.20)
Requirement already satisfied: ply==3.11 in /usr/lib/python3.12/site-packages (from pycparser->cffi>=1.17.0rc1) (3.11)
Downloading cffi-1.17.0rc1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (479 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 479.1/479.1 kB 21.2 MB/s eta 0:00:00
Installing collected packages: cffi
Successfully installed cffi-1.17.0rc1
$ pip --version
pip 24.1.1 ...
```
