### PR TITLE
pyproject: update cffi to 1.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cffi>=1.16.0; python_version <= '3.12'",
-    "cffi==1.17.0rc1; python_version >= '3.13'",
+    "cffi>=1.17.0; python_version >= '3.13'",
     # 69.0.0 breaks handling of --config-settings=--build-option, which our CI
     # relies on. So constrained to an older version until we figure out a
     # workaround. See comment at


### PR DESCRIPTION
And allow usage of versions >=1.17.0.