### PR TITLE
Move setuptools constraint to where --build-option is used

### DIFF
--- a/.github/workflows/external-zstd.yml
+++ b/.github/workflows/external-zstd.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
+        env:
+          PIP_CONSTRAINT: 'ci/constraints.txt'
         run: |
           python -m pip install --config-settings=--build-option=--system-zstd .
 
@@ -50,5 +52,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
+        env:
+          PIP_CONSTRAINT: 'ci/constraints.txt'
         run: |
           python -m pip install --config-settings=--build-option=--system-zstd .

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           version: "0.4.29"
       - name: Run Sphinx
+        env:
+          PIP_CONSTRAINT: 'ci/constraints.txt'
         run: |
           uv venv --python 3.12 venv
           source venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,8 @@ jobs:
       # TODO enable once PyO3 supports 3.13.
       - name: Build (Rust)
         if: matrix.arch == 'x64' && matrix.py != '3.13'
+        env:
+          PIP_CONSTRAINT: 'ci/constraints.txt'
         run: |
           python -m pip install --config-settings='--build-option=--rust-backend' -e .
 

--- a/ci/constraints.txt
+++ b/ci/constraints.txt
@@ -1,0 +1,5 @@
+# 69.0.0 breaks handling of --config-settings=--build-option, which our CI
+# relies on. So constrained to an older version until we figure out a
+# workaround. See comment at
+# https://github.com/pypa/pip/issues/11859#issuecomment-2132287974.
+setuptools<69.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,7 @@ Documentation = "https://python-zstandard.readthedocs.io/en/latest/"
 [build-system]
 requires = [
     "cffi>=1.17.0",
-    # 69.0.0 breaks handling of --config-settings=--build-option, which our CI
-    # relies on. So constrained to an older version until we figure out a
-    # workaround. See comment at
-    # https://github.com/pypa/pip/issues/11859#issuecomment-2132287974.
-    "setuptools<69.0.0",
+    "setuptools",
 ]
 # Need to use legacy backend because setup_zstd.py breaks build isolation.
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
Instead of restricting the version of setuptools used to build zstandard in every case, only limit it where necessary. This allows to pick setuptools fixes, like proper detection of newer versions of MSVC.

As a side effect, this fixes #240.