### PR TITLE
cffi: Support using `--system-zstd`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ if RUST_BACKEND:
 if CFFI_BACKEND and cffi:
     import make_cffi
 
-    extensions.append(make_cffi.ffi.distutils_extension())
+    extensions.append(make_cffi.get_ffi().distutils_extension())
 
 version = None
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ if RUST_BACKEND:
 if CFFI_BACKEND and cffi:
     import make_cffi
 
-    extensions.append(make_cffi.get_ffi().distutils_extension())
+    extensions.append(make_cffi.get_ffi(system_zstd=SYSTEM_ZSTD).distutils_extension())
 
 version = None
 


### PR DESCRIPTION
1. Refactor `make_cffi.py` to avoid performing the compilation in global scope, and allow passing parameters
2. Support `--system-zstd` with the CFFI backend. This uses the C preprocessor to find the system headers for, well, further preprocessing.

With these changes, I can successfully build the CFFI extension using system `zstd` library, and have it pass tests. I've also confirmed that it builds fine after removing the `zstd` directory entirely.