### PR TITLE
Work around the removed typing.ByteString (Python 3.14+)

### DIFF
--- a/zstandard/__init__.py
+++ b/zstandard/__init__.py
@@ -18,7 +18,10 @@ import builtins
 import io
 import os
 import platform
-from typing import ByteString
+from typing import Union
+
+# ByteString has been removed from typing in Python 3.14
+ByteString = Union[bytes, bytearray, memoryview]
 
 # Some Python implementations don't support C extensions. That's why we have
 # a CFFI implementation in the first place. The code here import one of our

--- a/zstandard/__init__.pyi
+++ b/zstandard/__init__.pyi
@@ -8,7 +8,6 @@ import os
 from typing import (
     IO,
     BinaryIO,
-    ByteString,
     Generator,
     Iterable,
     List,
@@ -17,6 +16,9 @@ from typing import (
     Tuple,
     Union,
 )
+
+# ByteString has been removed from typing in Python 3.14
+ByteString: Union[bytes, bytearray, memoryview]
 
 FLUSH_BLOCK: int
 FLUSH_FRAME: int


### PR DESCRIPTION
This should work in all the supported Pythons, starting from 3.8.