### PR TITLE
static metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,13 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 keywords = ["zstandard", "zstd", "compression"]
+dependencies = []
+
+[project.optional-dependencies]
+cffi = [
+  'cffi>=1.11 ; python_version < "3.13" and platform_python_implementation != "PyPy"',
+  'cffi>=1.17 ; python_version >= "3.13" and platform_python_implementation != "PyPy"',
+]
 
 [project.urls]
 Homepage = "https://github.com/indygreg/python-zstandard"
@@ -28,7 +35,7 @@ Documentation = "https://python-zstandard.readthedocs.io/en/latest/"
 
 [build-system]
 requires = [
-    "cffi>=1.17.0",
+    "cffi>=1.17.0 ; platform_python_implementation != 'PyPy'",
     "setuptools",
 ]
 # Need to use legacy backend because setup_zstd.py breaks build isolation.

--- a/setup.py
+++ b/setup.py
@@ -158,13 +158,5 @@ setup(
     ext_modules=extensions,
     cmdclass={"build_ext": setup_zstd.RustBuildExt},
     test_suite="tests",
-    install_requires=[
-        # cffi is required on PyPy.
-        "cffi>=%s; platform_python_implementation == 'PyPy'"
-        % MINIMUM_CFFI_VERSION
-    ],
-    extras_require={
-        "cffi": ["cffi>=%s" % MINIMUM_CFFI_VERSION],
-    },
     tests_require=["hypothesis"],
 )


### PR DESCRIPTION
Revisits #97, actually more or less reverses 84650b2

per that issue, it still is desirable that package metadata should be static.  That is not currently the case: some wheels say that they want `cffi >= 1.17`, while others say that they want `cffi >= 1.11`.

Meanwhile "cffi is required on PyPy." seems to be the opposite of reality.  As noted earlier in that file, PyPy vendors cffi - so it is the one python implementation where you definitely do not need a dependency on cffi.