### PR TITLE
Avoid crashes on Windows CI

### DIFF
--- a/.github/workflows/anaconda.yml
+++ b/.github/workflows/anaconda.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           source $CONDA/bin/activate env
           $CONDA/bin/conda install --yes --quiet --name env conda-build pip
-          pip install --require-hashes -r ci/requirements.txt
+          pip install --require-hashes -r ci/requirements.txt -c ci/constraints.txt
 
       - name: Build and Test
         run: |

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build
         run: |
-          python -m pip wheel -w wheelhouse .
+          python -m pip wheel -w wheelhouse . -c ci/constraints.txt
 
   test:
     strategy:
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install --require-hashes -r ci/requirements.pypy.txt
+          pip install --require-hashes -r ci/requirements.pypy.txt -c ci/constraints.txt
 
       - name: Build
         run: |

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -13,7 +13,6 @@ jobs:
           - 'macos-13'
           - 'windows-2022'
         py:
-          - 'pypy-3.9'
           - 'pypy-3.10'
         arch:
           - 'x86'
@@ -51,7 +50,6 @@ jobs:
           - 'macos-13'
           - 'windows-2022'
         py:
-          - 'pypy-3.9'
           - 'pypy-3.10'
         arch:
           - 'x86'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -133,7 +133,7 @@ jobs:
           export CIBW_ARCHS=ARM64
           export CIBW_BUILD=cp$(echo ${{ matrix.py }} | tr -d .)-*
           export CIBW_BUILD_VERBOSITY=1
-          cibuildwheel --output-dir dist --arch ARM64
+          PIP_CONSTRAINT=ci/constraints.txt cibuildwheel --output-dir dist --arch ARM64
 
       - name: Upload Wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Uses the existing constraints file to avoid crashes on Windows CI.

For PyPy 3.9 I don't think there's anything we can do because of https://github.com/pypy/pypy/issues/5027, which requires a fix inside PyPy, so I dropped PyPy 3.9 from CI.