### PR TITLE
build: Fix Win-ARM64 failing jobs in CI

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -108,7 +108,11 @@ jobs:
         exclude:
           - py: '3.8'
             arch: 'arm64'
-    runs-on: 'windows-2022'
+          - py: '3.9'
+            arch: 'arm64'
+          - py: '3.10'
+            arch: 'arm64'
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-2022' }}
     env:
       ZSTD_WARNINGS_AS_ERRORS: '1'
     steps:
@@ -116,24 +120,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-          architecture: ${{ matrix.arch == 'arm64' && 'x64' || matrix.arch }}
+          architecture: ${{ matrix.arch }}
 
       - uses: actions/checkout@v4
 
       - name: Build Wheel
-        if: matrix.arch != 'arm64'
         run: |
           python -m pip wheel -w dist .
-
-      - name: Build Wheel
-        if: matrix.arch == 'arm64'
-        shell: bash
-        run: |
-          python -m pip install cibuildwheel
-          export CIBW_ARCHS=ARM64
-          export CIBW_BUILD=cp$(echo ${{ matrix.py }} | tr -d .)-*
-          export CIBW_BUILD_VERBOSITY=1
-          cibuildwheel --output-dir dist --arch ARM64
 
       - name: Upload Wheel
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
PR Description:

- The PR fixes Windows ARM64 failing python wheel builds jobs
- Removed 3.8 to 3.10 builds from CI, since these version of Python binaries for Win-ARM64 are not available officially.
- Added new native WoA github runner to get native Python wheels for python-zstandard on Windows ARM64.
- Removed ARM64 assertations in cibw to make workflow cleaner and maintainable.