### PR TITLE
Fix signature of BufferWithSegmentsCollection_init

### DIFF
--- a/c-ext/bufferutil.c
+++ b/c-ext/bufferutil.c
@@ -382,7 +382,7 @@ BufferWithSegmentsCollection_dealloc(ZstdBufferWithSegmentsCollection *self) {
 
 static int
 BufferWithSegmentsCollection_init(ZstdBufferWithSegmentsCollection *self,
-                                  PyObject *args) {
+                                  PyObject *args, PyObject *kwargs) {
     Py_ssize_t size;
     Py_ssize_t i;
     Py_ssize_t offset = 0;


### PR DESCRIPTION
The correct signature for `tp_init` functions has three parameters; but the `BufferWithSegmentsCollection_init` just takes two. While most platforms allow calling functions with the wrong number of parameters, WebAssembly only allows calling functions with the correct signature.

This PR fixes that issue by adding the missing `PyObject *kwargs` parameter to `BufferWithSegmentsCollection_init`