### PR TITLE
feat: add riscv64 to Linux wheel build matrix

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -70,6 +70,33 @@ jobs:
             image: 'musllinux_1_1'
           - py: 'cp314t'
             image: 'musllinux_1_1'
+        include:
+          # riscv64 only has manylinux_2_28 (no manylinux2014, no musllinux).
+          # Using include entries to bypass the manylinux_2_28 excludes above.
+          - py: 'cp310'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
+          - py: 'cp311'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
+          - py: 'cp312'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
+          - py: 'cp313'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
+          - py: 'cp314'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
+          - py: 'cp314t'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_28'
     runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     env:
       CIBW_ARCHS: ${{ matrix.arch }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'ppc64le' || matrix.arch == 's390x' || matrix.arch == 'riscv64' }}
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Build wheels
         run: |

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -81,6 +81,7 @@ jobs:
       CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/${{ matrix.image }}_i686:latest
       CIBW_MANYLINUX_PPC64LE_IMAGE: quay.io/pypa/${{ matrix.image }}_ppc64le:latest
       CIBW_MANYLINUX_S390X_IMAGE: quay.io/pypa/${{ matrix.image }}_s390x:latest
+      CIBW_MANYLINUX_RISCV64_IMAGE: quay.io/pypa/${{ matrix.image }}_riscv64:latest
       CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.image }}_x86_64:latest
       CIBW_MUSLLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.image }}_aarch64:latest
       CIBW_MUSLLINUX_I686_IMAGE: quay.io/pypa/${{ matrix.image }}_i686:latest
@@ -98,7 +99,7 @@ jobs:
           version: "0.8.11"
 
       - name: Set up QEMU
-        if: ${{ matrix.arch == 'ppc64le' || matrix.arch == 's390x' }}
+        if: ${{ matrix.arch == 'ppc64le' || matrix.arch == 's390x' || matrix.arch == 'riscv64' }}
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Build wheels

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -71,7 +71,36 @@ jobs:
             image: 'musllinux_1_1'
           - py: 'cp314t'
             image: 'musllinux_1_1'
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+        include:
+          # riscv64 has manylinux_2_39 only: no manylinux2014, no musllinux.
+          # The excludes above rule manylinux_2_28 out for everything below
+          # 3.14, so these go in as include entries rather than another image
+          # value on the main matrix.
+          - py: 'cp310'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+          - py: 'cp311'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+          - py: 'cp312'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+          - py: 'cp313'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+          - py: 'cp314'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+          - py: 'cp314t'
+            arch: 'riscv64'
+            abi: 'manylinux'
+            image: 'manylinux_2_39'
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || matrix.arch == 'riscv64' && 'ubuntu-24.04-riscv' || 'ubuntu-24.04' }}
     env:
       CIBW_ARCHS: ${{ matrix.arch }}
       CIBW_BUILD: ${{ matrix.py }}-${{ matrix.abi }}_${{ matrix.arch }}
@@ -81,6 +110,7 @@ jobs:
       CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.image }}_aarch64:latest
       CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/${{ matrix.image }}_i686:latest
       CIBW_MANYLINUX_PPC64LE_IMAGE: quay.io/pypa/${{ matrix.image }}_ppc64le:latest
+      CIBW_MANYLINUX_RISCV64_IMAGE: quay.io/pypa/${{ matrix.image }}_riscv64:latest
       CIBW_MANYLINUX_S390X_IMAGE: quay.io/pypa/${{ matrix.image }}_s390x:latest
       CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/${{ matrix.image }}_x86_64:latest
       CIBW_MUSLLINUX_AARCH64_IMAGE: quay.io/pypa/${{ matrix.image }}_aarch64:latest


### PR DESCRIPTION
## Summary

Add `riscv64` to the Linux wheel matrix, built and tested on real riscv64 hardware rather than under emulation.

### Changes

- Six `include` entries (cp310 through cp314t) for `manylinux_2_39`. riscv64 has no `manylinux2014` and no `musllinux`, and the excludes rule `manylinux_2_28` out below 3.14, so include entries fit better than a fourth `image` value on the main matrix.
- `runs-on` sends riscv64 jobs to `ubuntu-24.04-riscv`.
- `CIBW_MANYLINUX_RISCV64_IMAGE`, alongside the other per-arch image variables.

Nothing else changes. Same `uvx -p 3.13 cibuildwheel@4.1.0` invocation, same `[tool.cibuildwheel]` config, no QEMU step, and the rest of the matrix is untouched. python-build-standalone publishes riscv64 CPython for 3.10 through 3.15, so `uvx -p 3.13` resolves on those runners without special-casing.

### About the runner, and what you will see on this PR

`ubuntu-24.04-riscv` is the label for the [RISE RISC-V runners](https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/), free managed GitHub Actions runners on bare-metal RISC-V hardware. They are opt-in per repository: someone with admin rights installs the [RISE RISC-V Runners app](https://github.com/apps/rise-risc-v-runners).

Until that happens, the six riscv64 jobs on this PR will sit queued and never start. That is worth knowing before you look at the checks and wonder what is stuck. The other jobs are unaffected.

### Why this changed since the first version

The earlier version of this PR ran riscv64 through QEMU, which works but is slow and tests the wheels on an emulator rather than on the hardware people will run them on. Reviewers on the RISE side pointed out that native is both faster and better evidence, so this is the reworked version. If you would rather not take on a runner dependency, I can go back to the QEMU form and it will build without any setup on your end.

### Evidence

- riscv64 wheels for 0.23.0, built natively on a BananaPi F3 (SpacemiT K1) and smoke tested: https://github.com/gounthar/riscv64-python-wheels/releases/tag/v2026.03.07-cp313
- RISE is preparing riscv64 zstandard wheels from this same cibuildwheel configuration in https://github.com/riseproject-dev/python-wheels/pull/161, so the build path here is the one under review there too.

### Context

- `manylinux_2_39_riscv64` is published by pypa/manylinux.
- Several packages already ship riscv64 wheels: aiohttp, yarl, multidict, propcache.
- zstandard is a common transitive dependency, so with no wheel it gets compiled from source on every install, which is what #288 and the comment on this PR from @eshattow describe.

Ref: #288
