### PR TITLE
fix: use minimal Protocols for stream writer/reader type stubs

### DIFF
--- a/zstandard/__init__.pyi
+++ b/zstandard/__init__.pyi
@@ -6,17 +6,25 @@
 
 import os
 from typing import (
-    IO,
     BinaryIO,
     ByteString,
     Generator,
     Iterable,
     List,
     Optional,
+    Protocol,
     Set,
     Tuple,
     Union,
 )
+
+
+class _Writable(Protocol):
+    def write(self, data: bytes, /) -> int: ...
+
+
+class _Readable(Protocol):
+    def read(self, size: int = ..., /) -> bytes: ...
 
 FLUSH_BLOCK: int
 FLUSH_FRAME: int
@@ -278,15 +286,15 @@ class ZstdCompressor(object):
     ) -> ZstdCompressionChunker: ...
     def copy_stream(
         self,
-        ifh: IO[bytes],
-        ofh: IO[bytes],
+        ifh: _Readable,
+        ofh: _Writable,
         size: int = ...,
         read_size: int = ...,
         write_size: int = ...,
     ) -> Tuple[int, int]: ...
     def stream_reader(
         self,
-        source: Union[IO[bytes], ByteString],
+        source: Union[ByteString, _Readable],
         size: int = ...,
         read_size: int = ...,
         *,
@@ -294,7 +302,7 @@ class ZstdCompressor(object):
     ) -> ZstdCompressionReader: ...
     def stream_writer(
         self,
-        writer: IO[bytes],
+        writer: _Writable,
         size: int = ...,
         write_size: int = ...,
         write_return_read: bool = ...,
@@ -303,7 +311,7 @@ class ZstdCompressor(object):
     ) -> ZstdCompressionWriter: ...
     def read_to_iter(
         self,
-        reader: Union[IO[bytes], ByteString],
+        reader: Union[ByteString, _Readable],
         size: int = ...,
         read_size: int = ...,
         write_size: int = ...,
@@ -396,25 +404,25 @@ class ZstdDecompressor(object):
     ) -> bytes: ...
     def stream_reader(
         self,
-        source: Union[IO[bytes], ByteString],
+        source: Union[ByteString, _Readable],
         read_size: int = ...,
         read_across_frames: bool = ...,
         *,
-        closefd=False,
+        closefd: bool = ...,
     ) -> ZstdDecompressionReader: ...
     def decompressobj(
         self, write_size: int = ..., read_across_frames: bool = False
     ) -> ZstdDecompressionObj: ...
     def read_to_iter(
         self,
-        reader: Union[IO[bytes], ByteString],
+        reader: Union[ByteString, _Readable],
         read_size: int = ...,
         write_size: int = ...,
         skip_bytes: int = ...,
     ) -> Generator[bytes, None, None]: ...
     def stream_writer(
         self,
-        writer: IO[bytes],
+        writer: _Writable,
         write_size: int = ...,
         write_return_read: bool = ...,
         *,
@@ -422,8 +430,8 @@ class ZstdDecompressor(object):
     ) -> ZstdDecompressionWriter: ...
     def copy_stream(
         self,
-        ifh: IO[bytes],
-        ofh: IO[bytes],
+        ifh: _Readable,
+        ofh: _Writable,
         read_size: int = ...,
         write_size: int = ...,
     ) -> Tuple[int, int]: ...


### PR DESCRIPTION
## Summary

Replace `IO[bytes]` with minimal `Protocol` classes (`_Writable` / `_Readable`) in type stubs for `stream_writer`, `stream_reader`, `copy_stream`, and `read_to_iter` on both `ZstdCompressor` and `ZstdDecompressor`.

## Motivation

The C extension only requires `.write()` on writer arguments and `.read()` on reader arguments — verified across all three backends (C, Rust, CFFI). Other methods like `.flush()`, `.close()`, `.fileno()` are guarded by `HasAttrString` / `getattr` and called only if present.

Using `IO[bytes]` as the annotation is overly restrictive. Objects that implement `.write()` but not the full `IO[bytes]` protocol (missing `mode`, `name`, `fileno`, `readlines`, `writelines`, `__iter__`, `__next__`, etc.) are rejected by type checkers despite working perfectly at runtime.

## Example

```python
import zstandard

class MinimalWriter:
    def write(self, data: bytes) -> int:
        return len(data)

cctx = zstandard.ZstdCompressor()
# Before: type checker error (MinimalWriter is not IO[bytes])
# After: passes type checking
writer = cctx.stream_writer(MinimalWriter())
```

This matters for libraries like [OpenDAL](https://github.com/apache/opendal) whose `File` object implements `.write()` / `.read()` but not the full `IO[bytes]` protocol, since it wraps cloud storage backends that don't support POSIX file semantics.

## Changes

- Add private `_Writable(Protocol)` with only `write(data: bytes) -> int`
- Add private `_Readable(Protocol)` with only `read(size: int = ...) -> bytes`
- Replace `IO[bytes]` parameter types with the appropriate protocol
- `Union[IO[bytes], ByteString]` becomes `Union[ByteString, _Readable]` (since `IO[bytes]` satisfies `_Readable`)
- Also fixes `closefd=False` → `closefd: bool = ...` in `ZstdDecompressor.stream_reader` (was missing type annotation)